### PR TITLE
fix: Bundle fonts and patch Comfyroll for NixOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Runtime packages (mutable):   <data-directory>/.pip-packages/
 
 A default manager config is created on first run with sensible defaults for personal use (`security_level=normal`, `network_mode=personal_cloud`).
 
+## Known Issues
+
+### Custom Nodes Requiring Patching
+
+Some custom nodes have hardcoded paths that don't exist on NixOS. We automatically patch these at startup, but **a full service restart is required after installing them via Manager**.
+
+| Node Pack | Issue | Fix |
+|-----------|-------|-----|
+| Comfyroll Studio (`ComfyUI_Comfyroll_CustomNodes`) | Hardcoded `/usr/share/fonts/truetype` | Patched to use bundled fonts |
+
+**After installing these nodes:** Stop ComfyUI completely (Ctrl+C) and restart with `nix run` or `systemctl restart comfyui`. Manager's internal restart does not trigger the patching.
+
 ## Bundled Custom Nodes
 
 The following custom nodes are bundled and automatically linked on first run:


### PR DESCRIPTION
## Summary

- Bundle fonts (DejaVu, Liberation, Noto, Roboto) from nixpkgs for custom nodes that require font files
- Auto-patch `ComfyUI_Comfyroll_CustomNodes` at startup to use bundled fonts instead of hardcoded `/usr/share/fonts/truetype`
- Fix ComfyUI-Manager config path (moved from `user/default/ComfyUI-Manager` to `user/__manager/`)
- Add Known Issues section to README documenting restart requirement after installing patched nodes

## Test plan

- [x] Install Comfyroll Studio via Manager
- [x] Full restart (Ctrl+C + `nix run`)
- [x] Verify "Patched ComfyUI_Comfyroll_CustomNodes for NixOS font compatibility" message appears
- [x] Verify `CR Select Font` node loads without `/usr/share/fonts/truetype` error
- [x] Verify fonts directory created in data dir with TTF symlinks

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)