### PR TITLE
fix(nix): disable filterpy tests on Darwin to avoid pytest BPT trap

### DIFF
--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -429,6 +429,13 @@ lib.optionalAttrs useCuda {
   });
 }
 
+# Disable filterpy tests on Darwin (test_hinfinity triggers BPT trap in pytest)
+// lib.optionalAttrs (prev ? filterpy) {
+  filterpy = prev.filterpy.overridePythonAttrs (old: {
+    doCheck = if pkgs.stdenv.isDarwin then false else (old.doCheck or true);
+  });
+}
+
 # Fix bitsandbytes build - needs ninja for wheel building phase
 // lib.optionalAttrs (prev ? bitsandbytes) {
   bitsandbytes = prev.bitsandbytes.overridePythonAttrs (old: {


### PR DESCRIPTION
## Description
The following error occurred on Darwin.
```
  warning: ignoring untrusted substituter 'https://comfyui.cachix.org', you are not a trusted user.
  Run `man nix.conf` for more information on the `substituters` configuration option.
  warning: ignoring untrusted substituter 'https://nix-community.cachix.org', you are not a trusted user.
  Run `man nix.conf` for more information on the `substituters` configuration option.
  warning: ignoring untrusted substituter 'https://cuda-maintainers.cachix.org', you are not a trusted user.
  Run `man nix.conf` for more information on the `substituters` configuration option.
  warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting
  and you are not a trusted user
  error: Cannot build '/nix/store/8amfb29g5q9k8mh2fw8v5775m48w7n4s-python3.12-filterpy-1.4.5-unstable-2022-
  08-23.drv'.
         Reason: builder failed with exit code 133.
         Output paths:
           /nix/store/sy76c91h48hbyih03c4nmysi3x99z8md-python3.12-filterpy-1.4.5-unstable-2022-08-23-dist
           /nix/store/vqy54gnbvk864mr5xglcgb9a7l6g1jbg-python3.12-filterpy-1.4.5-unstable-2022-08-23
         Last 25 log lines:
         > patching script interpreter paths in /nix/store/vqy54gnbvk864mr5xglcgb9a7l6g1jbg-python3.12-
  filterpy-1.4.5-unstable-2022-08-23
         > stripping (with command strip and flags -S) in  /nix/store/vqy54gnbvk864mr5xglcgb9a7l6g1jbg-
  python3.12-filterpy-1.4.5-unstable-2022-08-23/lib
         > checking for references to /nix/var/nix/builds/nix-28607-2225504076/ in /nix/store/
  sy76c91h48hbyih03c4nmysi3x99z8md-python3.12-filterpy-1.4.5-unstable-2022-08-23-dist...
         > patching script interpreter paths in /nix/store/sy76c91h48hbyih03c4nmysi3x99z8md-python3.12-
  filterpy-1.4.5-unstable-2022-08-23-dist
         > Executing pythonRemoveTestsDir
         > Finished executing pythonRemoveTestsDir
         > Running phase: installCheckPhase
         > no Makefile or custom installCheckPhase, doing nothing
         > Running phase: pythonCatchConflictsPhase
         > Running phase: pythonRemoveBinBytecodePhase
         > Running phase: pythonImportsCheckPhase
         > Executing pythonImportsCheckPhase
         > Running phase: pytestCheckPhase
         > Executing pytestCheckPhase
         > pytest flags: -m pytest -k not\ \(test_multivariate_gaussian\)
         > ============================= test session starts ==============================
         > platform darwin -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0
         > rootdir: /nix/var/nix/builds/nix-28607-2225504076/source
         > collected 74 items / 1 deselected / 73 selected
         >
         > filterpy/common/tests/test_discretization.py ...                         [  4%]
         > filterpy/common/tests/test_helpers.py .......                            [ 13%]
         > filterpy/discrete_bayes/tests/test_discrete_bayes.py .                   [ 15%]
         > filterpy/gh/tests/test_gh.py ....                                        [ 20%]
         > filterpy/hinfinity/tests/test_hinfinity.py /nix/store/09c9sskp507h4kd6id9gn0yijs5y3mhd-pytest-
  check-hook/nix-support/setup-hook: line 23: 29345 Trace/BPT trap: 5          /nix/store/
  nrk1773m026hlgkk7vlpvc2s6zlwf1rh-python3-3.12.12/bin/python3.12 "${flagsArray[@]}"
         For full logs, run:
           nix log /nix/store/8amfb29g5q9k8mh2fw8v5775m48w7n4s-python3.12-filterpy-1.4.5-unstable-2022-08-
  23.drv
  error: Cannot build '/nix/store/91bf945xzwbcxs9i4bp5awd8rrfg158k-python3-3.12.12-env.drv'.
         Reason: 1 dependency failed.
         Output paths:
           /nix/store/8rgrbs4n7ifmj29wjb6nj4iq8bqb4hn5-python3-3.12.12-env
  error: Cannot build '/nix/store/8gi4cjjxhw3w8532iammh4q1b886qqlv-comfy-ui.drv'.
         Reason: 1 dependency failed.
         Output paths:
           /nix/store/3kn8s7n2g0lnq4syd65wa6mqfma7v4dh-comfy-ui
  error: Cannot build '/nix/store/ll3w2dqi26gy1wxsky4q0xymgpwp9q0h-comfy-ui-0.7.0.drv'.
         Reason: 1 dependency failed.
         Output paths:
           /nix/store/cmcwjrccxvydzrfa80k064dd36vfk3dw-comfy-ui-0.7.0
```
## Changes
Override `filterpy` to set `doCheck = false` only on Darwin.