### PR TITLE
fix: remove deleted frog_depth_input.mp4 breaking build

### DIFF
--- a/nix/template-inputs.nix
+++ b/nix/template-inputs.nix
@@ -610,10 +610,8 @@ let
       url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/input/freckled_curly_girl.png";
       hash = "sha256-Qh3rE+6eKr1olayn78YhGfxjhV4pMfsIgrajXSkDoBc=";
     };
-    "frog_depth_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/input/frog_depth_input.mp4";
-      hash = "sha256-pvdGFA2FnGG6cfr948iVIGbgfuRIy8XS24TX0/WGw+I=";
-    };
+    # "frog_depth_input.mp4" removed — upstream file deleted from GitHub (404)
+    # See: https://github.com/utensils/comfyui-nix/issues/31
     "furry_ball.png" = {
       url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/input/furry_ball.png";
       hash = "sha256-BdLS4OFmmxrL40pO5vpxwG0hHcmoeH93SBNK8X6VFpc=";


### PR DESCRIPTION
## Summary

- Removes the `frog_depth_input.mp4` entry from `nix/template-inputs.nix`
- The upstream file (`comfyanonymous/ComfyUI_examples/blob/master/depth/frog_depth_input.mp4`) returns a 404 — it was deleted from the ComfyUI_examples repo
- This causes all builds to fail with a hash mismatch / fetch error

Fixes #31

## Test plan

- [x] `nix run github:Aypex/comfyui-nix#rocm` builds and launches successfully
- [x] ComfyUI starts with ROCm backend, no missing-file errors at runtime