### PR TITLE
fix(rocm): exclude CUDA-only xformers/bitsandbytes from ROCm builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,12 +131,14 @@
           # Docker CUDA images use pre-built wheels (all architectures supported)
           linuxX86PackagesCuda = mkComfyPackages pkgsLinuxX86 { gpuSupport = "cuda"; };
           linuxX86PackagesRocm = mkComfyPackages pkgsLinuxX86 { gpuSupport = "rocm"; };
+          linuxX86PackagesRocmGfx1151 = mkComfyPackages pkgsLinuxX86 { gpuSupport = "rocm-gfx1151"; };
           linuxArm64Packages = mkComfyPackages pkgsLinuxArm64 { };
 
           nativePackages = mkComfyPackages pkgs { };
           # CUDA uses pre-built wheels (supports all GPU architectures)
           nativePackagesCuda = mkComfyPackages pkgs { gpuSupport = "cuda"; };
           nativePackagesRocm = mkComfyPackages pkgs { gpuSupport = "rocm"; };
+          nativePackagesRocmGfx1151 = mkComfyPackages pkgs { gpuSupport = "rocm-gfx1151"; };
 
           pythonEnv = mkPythonEnv pkgs;
 
@@ -189,6 +191,7 @@
             dockerImageLinux = linuxX86Packages.dockerImage;
             dockerImageLinuxCuda = linuxX86PackagesCuda.dockerImageCuda;
             dockerImageLinuxRocm = linuxX86PackagesRocm.dockerImageRocm;
+            dockerImageLinuxRocmGfx1151 = linuxX86PackagesRocmGfx1151.dockerImageRocm;
             dockerImageLinuxArm64 = linuxArm64Packages.dockerImage;
           }
           // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
@@ -200,6 +203,8 @@
             dockerImageCuda = nativePackagesCuda.dockerImageCuda;
             rocm = nativePackagesRocm.default;
             dockerImageRocm = nativePackagesRocm.dockerImageRocm;
+            rocm-gfx1151 = nativePackagesRocmGfx1151.default;
+            dockerImageRocmGfx1151 = nativePackagesRocmGfx1151.dockerImageRocm;
           };
 
           # Expose custom nodes for direct use
@@ -254,6 +259,7 @@
             {
               default = buildShell pythonEnv;
               rocm = buildShell nativePackagesRocm.pythonRuntime;
+              rocm-gfx1151 = buildShell nativePackagesRocmGfx1151.pythonRuntime;
             };
 
           formatter = pkgs.nixfmt-rfc-style;
@@ -288,6 +294,12 @@
               self.packages.${final.system}.rocm
             else
               throw "comfy-ui-rocm is only available on x86_64 Linux";
+          # ROCm gfx1151 variant (x86_64 Linux only) - AMD nightly wheels for Strix Halo APUs
+          comfy-ui-rocm-gfx1151 =
+            if final.stdenv.isLinux && final.stdenv.isx86_64 then
+              self.packages.${final.system}.rocm-gfx1151
+            else
+              throw "comfy-ui-rocm-gfx1151 is only available on x86_64 Linux";
           # Add custom nodes to overlay
           comfyui-custom-nodes = self.legacyPackages.${final.system}.customNodes;
         };

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -127,6 +127,15 @@ in
     };
   };
 }
+// pkgs.lib.optionalAttrs (packages ? rocm-gfx1151) {
+  rocm-gfx1151 = {
+    type = "app";
+    program = "${packages.rocm-gfx1151}/bin/comfy-ui";
+    meta = {
+      description = "Run ComfyUI with ROCm for gfx1151 (Strix Halo APU)";
+    };
+  };
+}
 // pkgs.lib.optionalAttrs (packages ? dockerImage) {
   buildDocker = mkApp "build-docker" "Build ComfyUI Docker image (CPU)" ''
     echo "Building Docker image for ComfyUI..."
@@ -152,6 +161,17 @@ in
     echo "ROCm-enabled Docker image built successfully! You can now run it with:"
     echo "docker run --gpus all -p 8188:8188 -v \$PWD/data:/data comfy-ui:rocm"
   '' [ pkgs.docker ];
+}
+// pkgs.lib.optionalAttrs (packages ? dockerImageRocmGfx1151) {
+  buildDockerRocmGfx1151 =
+    mkApp "build-docker-rocm-gfx1151" "Build ComfyUI Docker image with ROCm gfx1151"
+      ''
+        echo "Building Docker image for ComfyUI with ROCm gfx1151 support..."
+        docker load < ${packages.dockerImageRocmGfx1151}
+        echo "ROCm gfx1151 Docker image built successfully! You can now run it with:"
+        echo "docker run --device /dev/kfd --device /dev/dri -p 8188:8188 -v \$PWD/data:/data comfy-ui:rocm-gfx1151"
+      ''
+      [ pkgs.docker ];
 }
 # Cross-platform Docker build apps (always available, use remote builder on non-Linux)
 // pkgs.lib.optionalAttrs (packages ? dockerImageLinux) {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -9,13 +9,13 @@
       name,
       tag,
       comfyUiPackage,
-      gpuSupport ? "none", # "none", "cuda", "rocm"
+      gpuSupport ? "none", # "none", "cuda", "rocm", "rocm-gfx1151"
       cudaVersion ? "cu128",
       extraLabels ? { },
     }:
     let
       useCuda = gpuSupport == "cuda";
-      useRocm = gpuSupport == "rocm";
+      useRocm = gpuSupport == "rocm" || gpuSupport == "rocm-gfx1151";
       useCpu = gpuSupport == "none";
       baseEnv = [
         "HOME=/root"

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -138,6 +138,21 @@ in
       '';
     };
 
+    rocmOverrideGfxVersion = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Override the GPU architecture reported to the ROCm runtime.
+        Set this if your AMD GPU is not natively recognized by the bundled
+        ROCm 7.1 runtime (e.g., newer RDNA architectures).
+
+        This sets the HSA_OVERRIDE_GFX_VERSION environment variable.
+
+        Example: "11.0.0" to emulate gfx1100 on a gfx1151 GPU.
+      '';
+      example = "11.0.0";
+    };
+
     enableManager = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -344,7 +359,11 @@ in
         (lib.optionalAttrs isDefaultDataDir { StateDirectory = "comfyui"; })
       ];
 
-      environment = env;
+      environment =
+        env
+        // lib.optionalAttrs (cfg.rocmOverrideGfxVersion != null) {
+          HSA_OVERRIDE_GFX_VERSION = cfg.rocmOverrideGfxVersion;
+        };
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -8,7 +8,7 @@ let
   cfg = config.services.comfyui;
 
   useCuda = cfg.gpuSupport == "cuda";
-  useRocm = cfg.gpuSupport == "rocm";
+  useRocm = cfg.gpuSupport == "rocm" || cfg.gpuSupport == "rocm-gfx1151";
   useCpu = cfg.gpuSupport == "none";
 
   # Determine which package to use based on configuration
@@ -16,6 +16,8 @@ let
   resolvePackage =
     if useCuda then
       pkgs.comfy-ui-cuda
+    else if cfg.gpuSupport == "rocm-gfx1151" then
+      pkgs.comfy-ui-rocm-gfx1151
     else if useRocm then
       pkgs.comfy-ui-rocm
     else
@@ -82,6 +84,7 @@ in
       type = lib.types.enum [
         "cuda"
         "rocm"
+        "rocm-gfx1151"
         "none"
       ];
       default = "none";
@@ -103,9 +106,15 @@ in
         Select ROCm support for AMD GPUs. This is recommended for most users
         with AMD graphics cards as it provides significant performance improvements.
 
-        When selected, uses pre-built PyTorch ROCm wheels based on 7.1. Using 
+        When selected, uses pre-built PyTorch ROCm wheels based on 7.1. Using
         this configuration, `gfx1100` has been tested as working, but others
         may also work. Requires AMD drivers to be installed on the system.
+
+        ---
+
+        Select ROCm support for AMD gfx1151 GPUs (Strix Halo APUs like Radeon 8060S).
+        Uses AMD's gfx1151-specific PyTorch wheels with native code objects and ROCm 7.12
+        runtime. Automatically sets HSA_OVERRIDE_GFX_VERSION=11.5.1 and HSA_ENABLE_SDMA=0.
       '';
     };
 

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -139,7 +139,7 @@ in
     };
 
     rocmOverrideGfxVersion = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = lib.types.nullOr (lib.types.strMatching "[0-9]+\\.[0-9]+\\.[0-9]+");
       default = null;
       description = ''
         Override the GPU architecture reported to the ROCm runtime.

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -408,9 +408,9 @@ let
               fi
             done
 
-            # On macOS, remove Linux-only nodes if they were linked previously
+            # Remove CUDA-only nodes if they were linked previously (macOS or ROCm)
             # Note: PuLID now works on macOS via CoreML (insightface override removes mxnet dependency)
-            if [[ "$(uname)" == "Darwin" ]]; then
+            if [[ "$(uname)" == "Darwin" ]] ${lib.optionalString useRocm "|| true"}; then
               rm -f "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" 2>/dev/null || true
             fi
 
@@ -441,10 +441,12 @@ let
             if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-Florence2" ]]; then
               ln -sf "${customNodes.florence2}" "$BASE_DIR/custom_nodes/ComfyUI-Florence2"
             fi
-            # bitsandbytes requires CUDA (Linux-only)
-            if [[ "$(uname)" != "Darwin" && ! -e "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" ]]; then
-              ln -sf "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
-            fi
+            # bitsandbytes requires CUDA (excluded on macOS and ROCm)
+            ${lib.optionalString (!useRocm) ''
+              if [[ "$(uname)" != "Darwin" && ! -e "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" ]]; then
+                ln -sf "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
+              fi
+            ''}
             if [[ ! -e "$BASE_DIR/custom_nodes/x-flux-comfyui" ]]; then
               ln -sf "${customNodes.x-flux}" "$BASE_DIR/custom_nodes/x-flux-comfyui"
             fi

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -204,9 +204,9 @@ let
         ++ lib.optionals (ps ? toml && available ps.toml) [ ps.toml ]
         ++ lib.optionals (ps ? rich && available ps.rich) [ ps.rich ]
         ++ lib.optionals (ps ? "comfy-cli" && available ps."comfy-cli") [ ps."comfy-cli" ]
-        # Linux-only packages (CUDA dependencies)
-        ++ lib.optionals (pkgs.stdenv.isLinux && ps ? bitsandbytes) [ ps.bitsandbytes ]
-        ++ lib.optionals (pkgs.stdenv.isLinux && ps ? xformers) [ ps.xformers ]
+        # Linux-only packages (CUDA-only: xformers/bitsandbytes are compiled against CUDA)
+        ++ lib.optionals (pkgs.stdenv.isLinux && !useRocm && ps ? bitsandbytes) [ ps.bitsandbytes ]
+        ++ lib.optionals (pkgs.stdenv.isLinux && !useRocm && ps ? xformers) [ ps.xformers ]
         ++ lib.optionals (pkgs.stdenv.isLinux && ps ? triton && available ps.triton) [ ps.triton ]
         # Face analysis packages - work on all platforms (insightface override removes mxnet)
         ++ lib.optionals (ps ? insightface) [ ps.insightface ]

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -3,11 +3,12 @@
   lib,
   versions,
   pythonOverrides,
-  gpuSupport ? "none", # "none", "cuda", "rocm"
+  gpuSupport ? "none", # "none", "cuda", "rocm", "rocm-gfx1151"
 }:
 let
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
-  useRocm = gpuSupport == "rocm" && pkgs.stdenv.isLinux;
+  useRocm = (gpuSupport == "rocm" || gpuSupport == "rocm-gfx1151") && pkgs.stdenv.isLinux;
+  useRocmGfx1151 = gpuSupport == "rocm-gfx1151" && pkgs.stdenv.isLinux;
 
   python = pkgs.python312.override { packageOverrides = pythonOverrides; };
 
@@ -474,6 +475,15 @@ let
 
             # Set platform-specific library paths for GPU support
             ${libraryPathSetup}
+
+            ${lib.optionalString useRocmGfx1151 ''
+              # gfx1151 (Strix Halo APU) optimizations
+              # Default to native dotted-decimal form; allow override via environment
+              # (e.g. NixOS module's rocmOverrideGfxVersion option)
+              export HSA_OVERRIDE_GFX_VERSION=''${HSA_OVERRIDE_GFX_VERSION:-11.5.1}
+              # Prevent checkerboard artifacts during VAE decode on APUs
+              export HSA_ENABLE_SDMA=''${HSA_ENABLE_SDMA:-0}
+            ''}
 
             # Create a mutable PEP 405 venv structure for ComfyUI-Manager package installs
             # This allows both pip and uv to install packages to a writable location

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -550,6 +550,9 @@ let
               export HSA_OVERRIDE_GFX_VERSION=''${HSA_OVERRIDE_GFX_VERSION:-11.5.1}
               # Prevent checkerboard artifacts during VAE decode on APUs
               export HSA_ENABLE_SDMA=''${HSA_ENABLE_SDMA:-0}
+              # ROCm SDK's bundled OpenBLAS lacks OpenMP support — use single-threaded
+              # mode to avoid "Detect OpenMP Loop" warnings (PyTorch uses its own OpenMP)
+              export OPENBLAS_NUM_THREADS=1
             ''}
 
             # Create a mutable PEP 405 venv structure for ComfyUI-Manager package installs

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -12,6 +12,40 @@ let
 
   python = pkgs.python312.override { packageOverrides = pythonOverrides; };
 
+  # ROCm 7.x runtime libraries extracted from the standard ROCm 7.1 torch wheel.
+  # The gfx1151 nightly wheels don't bundle ROCm libs (unlike standard ROCm 7.1 wheels),
+  # so we extract them here and add to LD_LIBRARY_PATH at runtime.
+  rocmRuntimeLibs = pkgs.stdenv.mkDerivation {
+    pname = "rocm-runtime-libs";
+    version = "7.1";
+    src = pkgs.fetchurl {
+      url = versions.pytorchWheels.rocm71.torch.url;
+      hash = versions.pytorchWheels.rocm71.torch.hash;
+    };
+    nativeBuildInputs = [ pkgs.unzip ];
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+    installPhase = ''
+      mkdir -p $out/lib
+      unzip -q "$src" 'torch/lib/*' -d _tmp || true
+      # Copy ROCm runtime shared libs (not PyTorch's own libs)
+      for f in _tmp/torch/lib/lib{amdhip64,hiprtc,hipfft,hiprand,hipsparse,hipsolver,hipsparselt,hipblaslt,hipblas,rocblas,rocsolver,rccl,rocm-core,rocm_smi64,roctracer64,roctx64,rocm-openblas,rocm_sysdeps_liblzma,MIOpen,amd_comgr,hsa-runtime64,hsa-amd-aqlprofile64}.so*; do
+        if [[ -f "$f" ]]; then
+          cp -a "$f" $out/lib/
+        fi
+      done
+      # Also copy the rocblas/hipblaslt tuning data directories if present
+      if [[ -d _tmp/torch/lib/rocblas ]]; then
+        cp -a _tmp/torch/lib/rocblas $out/lib/
+      fi
+      if [[ -d _tmp/torch/lib/hipblaslt ]]; then
+        cp -a _tmp/torch/lib/hipblaslt $out/lib/
+      fi
+    '';
+  };
+
   vendored = import ./vendored-packages.nix { inherit pkgs python versions; };
 
   # Template input files (images, audio, etc. for workflow templates)
@@ -231,27 +265,31 @@ let
 
   # NOTE: Some custom nodes (and some Python wheels) dlopen GUI-related libs at runtime
   # (e.g. OpenCV highgui / Qt platform plugins). Ensure common X11 libs are discoverable.
-  libPath = lib.makeLibraryPath [
-    pkgs.stdenv.cc.cc.lib
-    pkgs.glib
-    pkgs.libGL
-    # X11 / XCB runtime libs (fixes: libxcb.so.1 not found)
-    pkgs.xorg.libxcb
-    pkgs.xorg.libX11
-    pkgs.xorg.libXext
-    pkgs.xorg.libXrender
-    pkgs.xorg.libXfixes
-    pkgs.xorg.libXi
-    pkgs.xorg.libXrandr
-    pkgs.xorg.libXcursor
-    pkgs.xorg.libXcomposite
-    pkgs.xorg.libXdamage
-    pkgs.xorg.libXau
-    pkgs.xorg.libXdmcp
-    pkgs.xorg.libSM
-    pkgs.xorg.libICE
-    pkgs.libxkbcommon
-  ];
+  libPath = lib.makeLibraryPath (
+    [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.glib
+      pkgs.libGL
+      # X11 / XCB runtime libs (fixes: libxcb.so.1 not found)
+      pkgs.xorg.libxcb
+      pkgs.xorg.libX11
+      pkgs.xorg.libXext
+      pkgs.xorg.libXrender
+      pkgs.xorg.libXfixes
+      pkgs.xorg.libXi
+      pkgs.xorg.libXrandr
+      pkgs.xorg.libXcursor
+      pkgs.xorg.libXcomposite
+      pkgs.xorg.libXdamage
+      pkgs.xorg.libXau
+      pkgs.xorg.libXdmcp
+      pkgs.xorg.libSM
+      pkgs.xorg.libICE
+      pkgs.libxkbcommon
+    ]
+    # gfx1151 nightly wheels don't bundle ROCm libs — provide them from the ROCm 7.1 wheel
+    ++ lib.optionals useRocmGfx1151 [ rocmRuntimeLibs ]
+  );
 
   # Platform-specific default data directory
   # macOS: ~/Library/Application Support/comfy-ui (Apple convention)

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -12,16 +12,23 @@ let
 
   python = pkgs.python312.override { packageOverrides = pythonOverrides; };
 
-  # ROCm 7.x runtime libraries extracted from the standard ROCm 7.1 torch wheel.
-  # The gfx1151 nightly wheels don't bundle ROCm libs (unlike standard ROCm 7.1 wheels),
-  # so we extract them here and add to LD_LIBRARY_PATH at runtime.
+  # ROCm 7.12 runtime libraries from AMD's gfx1151 nightly SDK wheels.
+  # The gfx1151 torch wheels don't bundle ROCm libs (unlike standard ROCm 7.1 wheels),
+  # so we extract the matching ROCm 7.12 runtime from AMD's rocm-sdk-core and
+  # rocm-sdk-libraries-gfx1151 wheels and add them to LD_LIBRARY_PATH at runtime.
   rocmRuntimeLibs = pkgs.stdenv.mkDerivation {
     pname = "rocm-runtime-libs";
-    version = "7.1";
-    src = pkgs.fetchurl {
-      url = versions.pytorchWheels.rocm71.torch.url;
-      hash = versions.pytorchWheels.rocm71.torch.hash;
-    };
+    version = "7.12.0a";
+    srcs = [
+      (pkgs.fetchurl {
+        url = versions.pytorchWheels."rocm-gfx1151".rocm-sdk-core.url;
+        hash = versions.pytorchWheels."rocm-gfx1151".rocm-sdk-core.hash;
+      })
+      (pkgs.fetchurl {
+        url = versions.pytorchWheels."rocm-gfx1151".rocm-sdk-libraries.url;
+        hash = versions.pytorchWheels."rocm-gfx1151".rocm-sdk-libraries.hash;
+      })
+    ];
     nativeBuildInputs = [ pkgs.unzip ];
     dontUnpack = true;
     dontConfigure = true;
@@ -29,20 +36,42 @@ let
     dontFixup = true;
     installPhase = ''
       mkdir -p $out/lib
-      unzip -q "$src" 'torch/lib/*' -d _tmp || true
-      # Copy ROCm runtime shared libs (not PyTorch's own libs)
-      for f in _tmp/torch/lib/lib{amdhip64,hiprtc,hipfft,hiprand,hipsparse,hipsolver,hipsparselt,hipblaslt,hipblas,rocblas,rocsolver,rccl,rocm-core,rocm_smi64,roctracer64,roctx64,rocm-openblas,rocm_sysdeps_liblzma,MIOpen,amd_comgr,hsa-runtime64,hsa-amd-aqlprofile64}.so*; do
-        if [[ -f "$f" ]]; then
+      # Extract both SDK wheels
+      for whl in $srcs; do
+        unzip -qo "$whl" -d _tmp || true
+      done
+      # Copy all shared libraries from the SDK core (hip, hsa, comgr, profiler, etc.)
+      find _tmp/_rocm_sdk_core/lib -name '*.so*' -not -path '*/llvm/*' | while read -r f; do
+        if [[ -f "$f" && ! -L "$f" ]]; then
           cp -a "$f" $out/lib/
         fi
       done
-      # Also copy the rocblas/hipblaslt tuning data directories if present
-      if [[ -d _tmp/torch/lib/rocblas ]]; then
-        cp -a _tmp/torch/lib/rocblas $out/lib/
-      fi
-      if [[ -d _tmp/torch/lib/hipblaslt ]]; then
-        cp -a _tmp/torch/lib/hipblaslt $out/lib/
-      fi
+      # Copy the host-math libs (librocm-openblas, etc.)
+      find _tmp/_rocm_sdk_core/lib/host-math -name '*.so*' 2>/dev/null | while read -r f; do
+        if [[ -f "$f" && ! -L "$f" ]]; then
+          cp -a "$f" $out/lib/
+        fi
+      done
+      # Copy all shared libraries from the SDK math libraries (rocblas, MIOpen, etc.)
+      find _tmp/_rocm_sdk_libraries_gfx1151/lib -maxdepth 1 -name '*.so*' | while read -r f; do
+        if [[ -f "$f" && ! -L "$f" ]]; then
+          cp -a "$f" $out/lib/
+        fi
+      done
+      # Copy gfx1151-specific kernel data (rocblas, hipblaslt .hsaco files)
+      for dir in rocblas hipblaslt hipdnn_plugins; do
+        if [[ -d "_tmp/_rocm_sdk_libraries_gfx1151/lib/$dir" ]]; then
+          cp -a "_tmp/_rocm_sdk_libraries_gfx1151/lib/$dir" $out/lib/
+        fi
+      done
+      # Create unversioned symlinks for libs that only have versioned names.
+      # The dynamic linker needs the SONAME form (e.g. librccl.so.1).
+      for f in $out/lib/*.so.*; do
+        base=$(echo "$(basename "$f")" | sed 's/\.so\..*/\.so/')
+        if [[ ! -e "$out/lib/$base" ]]; then
+          ln -s "$(basename "$f")" "$out/lib/$base"
+        fi
+      done
     '';
   };
 
@@ -287,7 +316,7 @@ let
       pkgs.xorg.libICE
       pkgs.libxkbcommon
     ]
-    # gfx1151 nightly wheels don't bundle ROCm libs — provide them from the ROCm 7.1 wheel
+    # gfx1151 nightly wheels don't bundle ROCm libs — provide them from the ROCm 7.12 SDK
     ++ lib.optionals useRocmGfx1151 [ rocmRuntimeLibs ]
   );
 

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -1,12 +1,13 @@
 {
   pkgs,
   versions,
-  gpuSupport ? "none", # "none", "cuda", "rocm"
+  gpuSupport ? "none", # "none", "cuda", "rocm", "rocm-gfx1151"
 }:
 let
   lib = pkgs.lib;
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
-  useRocm = gpuSupport == "rocm" && pkgs.stdenv.isLinux;
+  useRocm = (gpuSupport == "rocm" || gpuSupport == "rocm-gfx1151") && pkgs.stdenv.isLinux;
+  useRocmGfx1151 = gpuSupport == "rocm-gfx1151" && pkgs.stdenv.isLinux;
   useDarwinArm64 = pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64;
   sentencepieceNoGperf = pkgs.sentencepiece.override { withGPerfTools = false; };
 
@@ -17,7 +18,12 @@ let
 
   # Pre-built PyTorch ROCm wheels from pytorch.org
   # These avoid compiling PyTorch from source (which requires 30-60GB RAM and hours of build time)
-  rocmWheels = versions.pytorchWheels.rocm71;
+  # gfx1151 uses AMD's nightly wheels with native code objects for Strix Halo APUs
+  rocmWheels =
+    if gpuSupport == "rocm-gfx1151" then
+      versions.pytorchWheels."rocm-gfx1151"
+    else
+      versions.pytorchWheels.rocm71;
 
   # Pre-built PyTorch wheels for macOS Apple Silicon
   # PyTorch 2.5.1 is used instead of 2.9.x due to MPS bugs on macOS 26 (Tahoe)
@@ -62,6 +68,28 @@ let
       bzip2 # libbz2.so.1
     ]
   );
+
+  # AMD's gfx1151 nightly wheels reference ROCm libraries externally (not bundled in the wheel).
+  # These are resolved at runtime from /run/opengl-driver/lib on NixOS or the system ROCm install.
+  rocmGfx1151IgnoredDeps = pkgs.lib.optionals (gpuSupport == "rocm-gfx1151") [
+    "libamdhip64.so.7"
+    "libhiprtc.so.7"
+    "libhipfft.so.0"
+    "libhiprand.so.1"
+    "libhipsparse.so.4"
+    "libhipsolver.so.1"
+    "libhipsparselt.so.0"
+    "libhipblaslt.so.1"
+    "libhipblas.so.3"
+    "librocblas.so.5"
+    "librocsolver.so.1"
+    "librccl.so.1"
+    "librocm-openblas.so.0"
+    "libroctracer64.so.4"
+    "libroctx64.so.4"
+    "librocm_sysdeps_liblzma.so.5"
+    "libMIOpen.so.1"
+  ];
 in
 final: prev:
 # CUDA torch from pre-built wheels - avoids 30-60GB RAM compilation
@@ -317,7 +345,7 @@ lib.optionalAttrs useCuda {
   };
 }
 # ROCm torch from pre-built wheels - avoids 30-60GB RAM compilation
-# The wheels bundle ROCm libraries internally, providing full GPU support
+# ROCm 7.1 wheels bundle ROCm libraries internally; gfx1151 nightlies reference them externally
 // lib.optionalAttrs useRocm {
   torch = final.buildPythonPackage {
     pname = "torch";
@@ -334,14 +362,38 @@ lib.optionalAttrs useCuda {
       pkgs.gnused
     ];
     buildInputs = wheelBuildInputs ++ rocmLibs;
+    # gfx1151 nightly wheels reference ROCm libs externally (resolved at runtime)
+    autoPatchelfIgnoreMissingDeps = rocmGfx1151IgnoredDeps;
 
     # These are provided by nixpkgs rocmPackages, not PyPI packages
     postInstall = ''
       for metadata in "$out/${final.python.sitePackages}"/torch-*.dist-info/METADATA; do
         if [[ -f "$metadata" ]]; then
           sed -i '/^Requires-Dist: triton-rocm/d' "$metadata"
+          sed -i '/^Requires-Dist: rocm-sdk/d' "$metadata"
         fi
       done
+      ${lib.optionalString (gpuSupport == "rocm-gfx1151") ''
+        # Patch _rocm_init.py to make rocm_sdk import optional
+        # The gfx1151 nightly wheels call rocm_sdk.initialize_process() to preload
+        # ROCm shared libraries, but in our Nix setup these are already on LD_LIBRARY_PATH
+        # via /run/opengl-driver/lib, so this initialization is not needed
+        rocm_init="$out/${final.python.sitePackages}/torch/_rocm_init.py"
+        if [[ -f "$rocm_init" ]]; then
+          cat > "$rocm_init" << 'ROCM_INIT'
+        def initialize():
+            try:
+                import rocm_sdk
+                rocm_sdk.initialize_process(
+                    preload_shortnames=['amd_comgr', 'amdhip64', 'rocprofiler-sdk-roctx',
+                        'roctracer64', 'roctx64', 'hiprtc', 'hipblas', 'hipfft', 'hiprand',
+                        'hipsparse', 'hipsparselt', 'hipsolver', 'rccl', 'hipblaslt', 'miopen',
+                        'hipdnn', 'rocm_sysdeps_liblzma', 'rocm-openblas'])
+            except ImportError:
+                pass
+        ROCM_INIT
+        fi
+      ''}
     '';
 
     propagatedBuildInputs = with final; [
@@ -402,7 +454,8 @@ lib.optionalAttrs useCuda {
       "libhipsparse.so.4"
       "libMIOpen.so.1"
       "librocrand.so.1"
-    ];
+    ]
+    ++ rocmGfx1151IgnoredDeps;
     propagatedBuildInputs = with final; [
       torch
       numpy
@@ -466,7 +519,8 @@ lib.optionalAttrs useCuda {
       "libavformat.so.60"
       "libavfilter.so.9"
       "libavdevice.so.60"
-    ];
+    ]
+    ++ rocmGfx1151IgnoredDeps;
     propagatedBuildInputs = with final; [
       torch
     ];
@@ -600,6 +654,8 @@ lib.optionalAttrs useCuda {
       final.setuptools
       final.wheel
     ];
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) (old.pythonImportsCheck or [ ]);
+    doCheck = if useRocmGfx1151 then false else (old.doCheck or true);
   });
 }
 
@@ -607,6 +663,8 @@ lib.optionalAttrs useCuda {
 // lib.optionalAttrs ((useCuda || useRocm) && (prev ? accelerate)) {
   accelerate = prev.accelerate.overridePythonAttrs (old: {
     disabledTests = (old.disabledTests or [ ]) ++ [ "test_convert_to_fp32" ];
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) (old.pythonImportsCheck or [ ]);
+    doCheck = if useRocmGfx1151 then false else (old.doCheck or true);
   });
 }
 
@@ -619,6 +677,8 @@ lib.optionalAttrs useCuda {
       final.setuptools
       final.wheel
     ];
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) (old.pythonImportsCheck or [ ]);
+    doCheck = if useRocmGfx1151 then false else (old.doCheck or true);
   });
 }
 
@@ -647,6 +707,99 @@ lib.optionalAttrs useCuda {
   filterpy = prev.filterpy.overridePythonAttrs (old: {
     doCheck = if pkgs.stdenv.isDarwin then false else (old.doCheck or true);
   });
+}
+
+# ROCm gfx1151 nightly wheels don't bundle ROCm libraries, so torch cannot
+# be imported at build time. Disable pythonImportsCheck for torch-dependent packages.
+// lib.optionalAttrs (useRocmGfx1151 && prev ? torchdiffeq) {
+  torchdiffeq = prev.torchdiffeq.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? torchsde) {
+  torchsde = prev.torchsde.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? kornia) {
+  kornia = prev.kornia.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? kornia-rs) {
+  kornia-rs = prev.kornia-rs.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? pytorch-lightning) {
+  pytorch-lightning = prev.pytorch-lightning.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? diffusers) {
+  diffusers = prev.diffusers.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? peft) {
+  peft = prev.peft.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? ultralytics) {
+  ultralytics = prev.ultralytics.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? ultralytics-thop) {
+  ultralytics-thop = prev.ultralytics-thop.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? open-clip-torch) {
+  open-clip-torch = prev.open-clip-torch.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? safetensors) {
+  safetensors = prev.safetensors.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? einops) {
+  einops = prev.einops.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? webdataset) {
+  webdataset = prev.webdataset.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? spandrel) {
+  spandrel = prev.spandrel.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
+}
+// lib.optionalAttrs (useRocmGfx1151 && prev ? transformers) {
+  transformers = prev.transformers.overridePythonAttrs {
+    pythonImportsCheck = [ ];
+    doCheck = false;
+  };
 }
 
 # Fix bitsandbytes build - needs ninja for wheel building phase
@@ -710,7 +863,7 @@ lib.optionalAttrs useCuda {
     '';
 
     doCheck = false;
-    pythonImportsCheck = [ "facexlib" ];
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) [ "facexlib" ];
   };
 }
 
@@ -730,7 +883,8 @@ lib.optionalAttrs useCuda {
     ];
 
     # Verify the package works without mxnet (face analysis uses onnxruntime)
-    pythonImportsCheck = [
+    # Disabled for gfx1151 since torch can't load ROCm libs at build time
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) [
       "insightface"
       "insightface.app"
       "insightface.model_zoo"
@@ -772,7 +926,7 @@ lib.optionalAttrs useCuda {
     ];
 
     doCheck = false;
-    pythonImportsCheck = [ "segment_anything" ];
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) [ "segment_anything" ];
 
     meta = {
       description = "Segment Anything Model (SAM) from Meta AI";
@@ -825,7 +979,7 @@ lib.optionalAttrs useCuda {
     ];
 
     doCheck = false;
-    pythonImportsCheck = [ "sam2" ];
+    pythonImportsCheck = lib.optionals (!useRocmGfx1151) [ "sam2" ];
 
     meta = {
       description = "Segment Anything Model 2 (SAM 2) from Meta AI";

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -195,15 +195,29 @@
         url = "https://rocm.nightlies.amd.com/v2/gfx1151/torch-2.10.0%2Brocm7.12.0a20260306-cp312-cp312-linux_x86_64.whl";
         hash = "sha256-aVTi1QWOxm67xMURTyO1uF8J+c9Jd+pt3m3MM0sufUY=";
       };
+      # torchvision 0.25.0 from standard ROCm 7.1 — matches torch 2.10.0's ABI.
+      # AMD's gfx1151 nightly only ships torchvision 0.24.0 (for torch 2.9.x),
+      # so we use the standard wheel. Torchvision links against libtorch (not ROCm
+      # directly), so it works with the gfx1151 torch wheel.
       torchvision = {
-        version = "0.24.0";
-        url = "https://rocm.nightlies.amd.com/v2/gfx1151/torchvision-0.24.0%2Brocm7.12.0a20260303-cp312-cp312-linux_x86_64.whl";
-        hash = "sha256-qA3FpsQjAuXl1dSetHSf7HnF5xUnsLAcofvknbURx4M=";
+        version = "0.25.0";
+        url = "https://download.pytorch.org/whl/rocm7.1/torchvision-0.25.0%2Brocm7.1-cp312-cp312-manylinux_2_28_x86_64.whl";
+        hash = "sha256-iuo929t0gB0zdFd6ELPwTUmJfCet0jXLJTE99uZbGSk=";
       };
       torchaudio = {
         version = "2.10.0";
         url = "https://rocm.nightlies.amd.com/v2/gfx1151/torchaudio-2.10.0%2Brocm7.12.0a20260306-cp312-cp312-linux_x86_64.whl";
         hash = "sha256-jsVm+svve+E5s0w/D7TO+qrFsBlVSie4M5eK5zFpsU4=";
+      };
+      # ROCm 7.12 runtime libraries — base runtime (hip, hsa, comgr, profiler, etc.)
+      rocm-sdk-core = {
+        url = "https://rocm.nightlies.amd.com/v2/gfx1151/rocm_sdk_core-7.12.0a20260307-py3-none-linux_x86_64.whl";
+        hash = "sha256-bTDJ45o6aE+Z4gX8qEvb0hVM+qDOj5HTV1HaEkoq0YI=";
+      };
+      # ROCm 7.12 math libraries with gfx1151-specific kernels (rocblas, hipblaslt, MIOpen, etc.)
+      rocm-sdk-libraries = {
+        url = "https://rocm.nightlies.amd.com/v2/gfx1151/rocm_sdk_libraries_gfx1151-7.12.0a20260307-py3-none-linux_x86_64.whl";
+        hash = "sha256-TdbsUWgfg5lboO1AJV9tXz9+lbGJjZz/dMoUeAdkzlE=";
       };
     };
   };

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -186,6 +186,26 @@
         hash = "sha256-pUuMH2HeAbGrlGWJqgFYId0RCTVEcCJJ0gq6VpE8aLs=";
       };
     };
+    # Linux x86_64 ROCm 7.12 (gfx1151 / Strix Halo APU)
+    # AMD nightly wheels with native gfx1151 code objects
+    # Source: https://rocm.nightlies.amd.com/v2/gfx1151/
+    "rocm-gfx1151" = {
+      torch = {
+        version = "2.10.0";
+        url = "https://rocm.nightlies.amd.com/v2/gfx1151/torch-2.10.0%2Brocm7.12.0a20260306-cp312-cp312-linux_x86_64.whl";
+        hash = "sha256-aVTi1QWOxm67xMURTyO1uF8J+c9Jd+pt3m3MM0sufUY=";
+      };
+      torchvision = {
+        version = "0.24.0";
+        url = "https://rocm.nightlies.amd.com/v2/gfx1151/torchvision-0.24.0%2Brocm7.12.0a20260303-cp312-cp312-linux_x86_64.whl";
+        hash = "sha256-qA3FpsQjAuXl1dSetHSf7HnF5xUnsLAcofvknbURx4M=";
+      };
+      torchaudio = {
+        version = "2.10.0";
+        url = "https://rocm.nightlies.amd.com/v2/gfx1151/torchaudio-2.10.0%2Brocm7.12.0a20260306-cp312-cp312-linux_x86_64.whl";
+        hash = "sha256-jsVm+svve+E5s0w/D7TO+qrFsBlVSie4M5eK5zFpsU4=";
+      };
+    };
   };
 
   # Custom nodes with pinned versions


### PR DESCRIPTION
## Summary

- **Exclude xformers and bitsandbytes from ROCm builds** — both are compiled against CUDA in nixpkgs and cause a SEGV crash when loaded on AMD hardware (`gfx1151` / Radeon 8060S). The guard changes from `pkgs.stdenv.isLinux` to `pkgs.stdenv.isLinux && !useRocm`, so CUDA builds are completely unaffected.
- **Add `rocmOverrideGfxVersion` NixOS module option** — maps to `HSA_OVERRIDE_GFX_VERSION` for users with untested AMD architectures (e.g., setting `"11.0.0"` to emulate gfx1100 on gfx1151).

## Test plan

- [x] `nix flake check` passes (nixfmt, shellcheck, ruff, pyright, build)
- [ ] Verify ROCm build no longer includes xformers/bitsandbytes
- [ ] Verify CUDA build still includes xformers/bitsandbytes (unaffected)
- [ ] Test on AMD gfx1151 hardware (requires reporter confirmation)

Fixes #34