### PR TITLE
chore: update ComfyUI v0.16.4 → v0.17.2 with all vendored deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgraded ComfyUI from v0.16.4 to v0.17.2 (3 upstream releases)
+- Updated `comfyui-frontend-package` 1.39.19 → 1.41.20
+- Updated `comfyui-workflow-templates` 0.9.11 → 0.9.21
+- Updated `comfyui-workflow-templates-core` 0.3.159 → 0.3.168
+- Updated `comfyui-workflow-templates-media-api` 0.3.59 → 0.3.64
+- Updated `comfyui-workflow-templates-media-video` 0.3.57 → 0.3.60
+- Updated `comfyui-workflow-templates-media-image` 0.3.98 → 0.3.104
+- Updated `comfyui-workflow-templates-media-other` 0.3.131 → 0.3.141
+- Updated `comfyui-manager` 4.0.5 → 4.1b2
+- Updated `comfy-kitchen` 0.2.7 → 0.2.8
+- Updated `comfy-aimdo` 0.2.7 → 0.2.10
+
+### Added
+- `blake3` Python dependency (new upstream requirement)
+
+### Upstream Highlights (v0.16.5 – v0.17.2)
+- Assets refactor: modular architecture with async two-phase scanner and background seeder
+- Flux 2 Klein KV Cache model support (new `FluxKVCache` node) with lower memory usage
+- Pre-attention patches API for Flux models; post-input patches for Qwen image model
+- New nodes: Painter node, Reve Image API nodes
+- Lora fix for text encoder loading on wrapped models
+- `torch.AcceleratorError` guard for torch < 2.8.0 compatibility
+- Python faulthandler enabled by default for better crash diagnostics
+- Bug fixes: batch_size > 1, OOM handling, audio extraction/truncation, Float gradient_stops
+
+## [0.16.4] - 2026-03-20
+
+### Changed
+- Upgraded ComfyUI from v0.14.2 to v0.16.4 with all vendored deps (#40)
+- Updated `comfyui-frontend-package` 1.38.14 → 1.39.19
+- Updated `comfyui-workflow-templates` 0.8.43 → 0.9.11
+- Updated `comfyui-workflow-templates-core` 0.3.147 → 0.3.159
+- Updated `comfyui-workflow-templates-media-api` 0.3.54 → 0.3.59
+- Updated `comfyui-workflow-templates-media-video` 0.3.49 → 0.3.57
+- Updated `comfyui-workflow-templates-media-image` 0.3.90 → 0.3.98
+- Updated `comfyui-workflow-templates-media-other` 0.3.123 → 0.3.131
+- Updated `comfyui-embedded-docs` 0.4.1 → 0.4.3
+- Updated `comfy-kitchen` 0.1.8 → 0.2.7
+- Updated `comfy-aimdo` 0.1.8 → 0.2.7
+- Updated all vendored custom node pins
+
+### Fixed
+- Added RTX 5090 (Blackwell / sm_120) CUDA support (#39)
+- Pinned template input URLs to commit hashes (#36)
+
 ## [0.14.2] - 2026-02-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Version Management
 
-- Current ComfyUI version: v0.16.4 (pinned in `nix/versions.nix`)
+- Current ComfyUI version: v0.17.2 (pinned in `nix/versions.nix`)
 - To update ComfyUI: modify `version`, `rev`, and `hash` in `nix/versions.nix`
 - Vendored wheels (spandrel, frontend, docs, etc.) also pinned in `nix/versions.nix`
 - Template input files: auto-generated in `nix/template-inputs.nix`
@@ -71,9 +71,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - **apps.nix**: Flake app definitions (run, update, Docker build commands)
   - **docker.nix**: Docker image builders
   - **checks.nix**: CI check definitions (ruff, pyright, nixfmt, shellcheck)
+  - **custom-nodes.nix**: Bundled custom node package definitions
   - **modules/comfyui.nix**: NixOS service module with declarative custom nodes
   - **lib/custom-nodes.nix**: Helper functions for custom node management
 - **scripts/**: Maintenance scripts (update-template-inputs.sh, push-to-cachix.sh, download-pulid-models.sh)
+
+### GPU Support Architecture
+
+The `gpuSupport` parameter is a string enum (`"none"`, `"cuda"`, `"rocm"`) that flows through the entire build:
+
+`flake.nix` → `packages.nix` / `python-overrides.nix` / `docker.nix` / `apps.nix` / `modules/comfyui.nix`
+
+Each module branches on this value to select platform-specific PyTorch wheels, runtime libraries, environment variables, and launcher behavior. When adding a new GPU backend, every file in this chain needs updates.
 
 ### Key Components
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A Nix flake for ComfyUI v0.14.2 with Python 3.12";
+  description = "A Nix flake for ComfyUI v0.17.2 with Python 3.12";
 
   nixConfig = {
     extra-substituters = [

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -128,6 +128,7 @@ let
         alembic
         sqlalchemy
         av
+        blake3
         pydantic-settings
         simpleeval
       ];
@@ -422,46 +423,24 @@ let
               find "$BASE_DIR/web/extensions" -maxdepth 1 -type d ! -writable -exec rm -rf {} \; 2>/dev/null || true
             fi
 
-            # Link bundled nodes
-            if [[ ! -e "$BASE_DIR/custom_nodes/model_downloader" ]]; then
-              ln -sf "${modelDownloaderDir}" "$BASE_DIR/custom_nodes/model_downloader"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-Impact-Pack" ]]; then
-              ln -sf "${customNodes.impact-pack}" "$BASE_DIR/custom_nodes/ComfyUI-Impact-Pack"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/rgthree-comfy" ]]; then
-              ln -sf "${customNodes.rgthree-comfy}" "$BASE_DIR/custom_nodes/rgthree-comfy"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-KJNodes" ]]; then
-              ln -sf "${customNodes.kjnodes}" "$BASE_DIR/custom_nodes/ComfyUI-KJNodes"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-GGUF" ]]; then
-              ln -sf "${customNodes.gguf}" "$BASE_DIR/custom_nodes/ComfyUI-GGUF"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-LTXVideo" ]]; then
-              ln -sf "${customNodes.ltxvideo}" "$BASE_DIR/custom_nodes/ComfyUI-LTXVideo"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-Florence2" ]]; then
-              ln -sf "${customNodes.florence2}" "$BASE_DIR/custom_nodes/ComfyUI-Florence2"
-            fi
+            # Link bundled nodes (always update symlinks to pick up new Nix store paths)
+            ln -sfn "${modelDownloaderDir}" "$BASE_DIR/custom_nodes/model_downloader"
+            ln -sfn "${customNodes.impact-pack}" "$BASE_DIR/custom_nodes/ComfyUI-Impact-Pack"
+            ln -sfn "${customNodes.rgthree-comfy}" "$BASE_DIR/custom_nodes/rgthree-comfy"
+            ln -sfn "${customNodes.kjnodes}" "$BASE_DIR/custom_nodes/ComfyUI-KJNodes"
+            ln -sfn "${customNodes.gguf}" "$BASE_DIR/custom_nodes/ComfyUI-GGUF"
+            ln -sfn "${customNodes.ltxvideo}" "$BASE_DIR/custom_nodes/ComfyUI-LTXVideo"
+            ln -sfn "${customNodes.florence2}" "$BASE_DIR/custom_nodes/ComfyUI-Florence2"
             # bitsandbytes requires CUDA (Linux-only)
-            if [[ "$(uname)" != "Darwin" && ! -e "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" ]]; then
-              ln -sf "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
+            if [[ "$(uname)" != "Darwin" ]]; then
+              ln -sfn "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
             fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/x-flux-comfyui" ]]; then
-              ln -sf "${customNodes.x-flux}" "$BASE_DIR/custom_nodes/x-flux-comfyui"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-MMAudio" ]]; then
-              ln -sf "${customNodes.mmaudio}" "$BASE_DIR/custom_nodes/ComfyUI-MMAudio"
-            fi
+            ln -sfn "${customNodes.x-flux}" "$BASE_DIR/custom_nodes/x-flux-comfyui"
+            ln -sfn "${customNodes.mmaudio}" "$BASE_DIR/custom_nodes/ComfyUI-MMAudio"
             # PuLID - face ID for consistent face generation
             # Works on all platforms: Linux uses CUDA, macOS uses CoreML via onnxruntime
-            if [[ ! -e "$BASE_DIR/custom_nodes/PuLID_ComfyUI" ]]; then
-              ln -sf "${customNodes.pulid}" "$BASE_DIR/custom_nodes/PuLID_ComfyUI"
-            fi
-            if [[ ! -e "$BASE_DIR/custom_nodes/ComfyUI-WanVideoWrapper" ]]; then
-              ln -sf "${customNodes.wanvideo}" "$BASE_DIR/custom_nodes/ComfyUI-WanVideoWrapper"
-            fi
+            ln -sfn "${customNodes.pulid}" "$BASE_DIR/custom_nodes/PuLID_ComfyUI"
+            ln -sfn "${customNodes.wanvideo}" "$BASE_DIR/custom_nodes/ComfyUI-WanVideoWrapper"
 
             # Create default ComfyUI-Manager config if it doesn't exist
             # Note: Manager moved config from user/default/ComfyUI-Manager to user/__manager

--- a/nix/template-inputs.nix
+++ b/nix/template-inputs.nix
@@ -11,1559 +11,1763 @@ let
   # All template input files with their URLs and hashes
   inputFiles = {
     "02_qwen_Image_edit_subgraphed_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/02_qwen_Image_edit_subgraphed_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/02_qwen_Image_edit_subgraphed_input_image.png";
       hash = "sha256-59bT3r+KLjOVC6FxJv/nqb0i2hh2xAljavb3R6KsEjA=";
     };
     "03_video_wan2_2_14B_i2v_subgraphed_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/03_video_wan2_2_14B_i2v_subgraphed_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/03_video_wan2_2_14B_i2v_subgraphed_input_image.png";
       hash = "sha256-j9P3/eDmdh2A5nkNN/TfRFScegnwyMaS/8wSyQtZkFY=";
     };
     "04_hunyuan_3d_2.1_subgraphed_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/04_hunyuan_3d_2.1_subgraphed_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/04_hunyuan_3d_2.1_subgraphed_input_image.png";
       hash = "sha256-SGLOW2OPYQvQrDF0dZVSBGEZ6LWfmC3W0U1Yl6CwGfI=";
     };
     "1950_new_york.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/1950_new_york.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/1950_new_york.png";
       hash = "sha256-5UO/5aN/MZkUThHaQYAKn7EaQs3T/86CDMCroxmYVZM=";
     };
     "2_pass_pose_worship_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/2_pass_pose_worship_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/2_pass_pose_worship_input.png";
       hash = "sha256-2D2VWXfj+QUzEC4PNuqqjkdIMWk4yO2Jh2OULFHXmgA=";
     };
     "2x2_grid_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/2x2_grid_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/2x2_grid_image.png";
       hash = "sha256-/UAoFuXFv1NpepFLl8pcPCY38UAdKpwEmNWdmwtZPN0=";
     };
     "3d_character_back_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_character_back_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_character_back_view.png";
       hash = "sha256-sSkd69s+7Cm3C4QGoMXQo+jsKgURWZ/0701kewPGdXU=";
     };
     "3d_character_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_character_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_character_front_view.png";
       hash = "sha256-6eKd35/x3RG+QaVyDx0Q8nauEgpJ/Iii50b1R5QvP2Q=";
     };
     "3d_character_left_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_character_left_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_character_left_view.png";
       hash = "sha256-KWVsU4PsYEfVB8bZIqd/0San7X4JYI7Fz/k6cr5/dZ4=";
     };
     "3d_hunyuan3d-v2.1_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d-v2.1_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d-v2.1_input_image.png";
       hash = "sha256-tojqBCMgbT8gixzRktQbDRG/VAkgsu6gUi8y2DXaDD4=";
     };
     "3d_hunyuan3d_image_to_model_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_image_to_model_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_image_to_model_input_image.png";
       hash = "sha256-AA+/kxSPY4Fq6nZUAOmMv0kWqHtJKNcQb8CSrH8Jrzk=";
     };
     "3d_hunyuan3d_multiview_to_model_back_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_back_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_back_image.png";
       hash = "sha256-HAdO5wQRGSkuvRJiSzP4K4kAmAm+zgcPDJchT9QzIg4=";
     };
     "3d_hunyuan3d_multiview_to_model_front_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_front_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_front_image.png";
       hash = "sha256-6Cklgrwi8Uhf4KUdfeIIipKphVXWA8YkUPxfcPRBbtg=";
     };
     "3d_hunyuan3d_multiview_to_model_left_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_left_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_left_image.png";
       hash = "sha256-uf8zSzu5i/2WXtt/+FkNks13shC5rtBfcxzq1DtCjow=";
     };
     "3d_hunyuan3d_multiview_to_model_right_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_right_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_right_image.png";
       hash = "sha256-owB6TRcfwncBz8cLX6kl56UC9Qo8Trl7KrtEQoamPzE=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_back_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_turbo_back_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_turbo_back_view.png";
       hash = "sha256-O9mvgB1fwrOM4tMWx8aL6iFhicg2Og/hmq7FxTS3uzc=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_turbo_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_turbo_front_view.png";
       hash = "sha256-d4RmlAT27B6V7nQcZyE0NAekpr8PCjUryQAi6QNy57w=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_left_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_turbo_left_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_turbo_left_view.png";
       hash = "sha256-35xmPXOjvKNNzmYrNPU2eZNcFvA3tOkYWrWnt2H1urY=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_right_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/3d_hunyuan3d_multiview_to_model_turbo_right_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/3d_hunyuan3d_multiview_to_model_turbo_right_view.png";
       hash = "sha256-0PSEki9dwDX3jkKHdZC4ariiHfBHVjqQdPuTPBqhZQ0=";
     };
     "6-key-frames-1.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/6-key-frames-1.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/6-key-frames-1.jpg";
       hash = "sha256-E6wSB459UrZQ4oEMRjoYvCfL4OqTKZxhqxVWDzlrC+E=";
     };
     "6-key-frames-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/6-key-frames-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/6-key-frames-2.png";
       hash = "sha256-gLAlOFl9+UoZV0mTURdZyXyMh421i7HUhBEAPLuhXzk=";
     };
     "6-key-frames-3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/6-key-frames-3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/6-key-frames-3.png";
       hash = "sha256-GlxZBG8ObuZPnXMI0vMC/+QKna3QD05rY7M3dD393tg=";
     };
     "6-key-frames-4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/6-key-frames-4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/6-key-frames-4.png";
       hash = "sha256-OPHcp5StWDzyvSwPBJtCWmn9oWyPn3QVHkNJ4Qxm6Gc=";
     };
     "6-key-frames-5.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/6-key-frames-5.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/6-key-frames-5.png";
       hash = "sha256-s8hYVFsJcXJyaZ1WSmVOu3q/UG7kja787nlBcnBOITY=";
     };
     "6-key-frames-6.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/6-key-frames-6.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/6-key-frames-6.png";
       hash = "sha256-7a1lfkqn1s8nLYP1cnWLjBAoknhwpJj09EkFQcdJW3s=";
     };
+    "AIrt_MAchIne_init.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/AIrt_MAchIne_init.png";
+      hash = "sha256-4fk+U9wehDQpn4dri0i9pQojEX6BIO7SZi7d4jUIUDs=";
+    };
     "Init.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/Init.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/Init.png";
       hash = "sha256-jHPUl+kEbdANdw4RqNb+HXZsARPudb5Y7/3gtdSl0yA=";
     };
     "Mask.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/Mask.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/Mask.mp4";
       hash = "sha256-ivKD5I1yyWZTUTGZCVdjuXRWewwIS0f5rY9Bq3gmE2c=";
     };
     "Noise_injection.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/Noise_injection.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/Noise_injection.mp4";
       hash = "sha256-pKp3AbS/tIVJTcibTiGtK1d4C1u+rrpLM4RBYVtD+Yk=";
     };
     "Urban_Fashion.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/Urban_Fashion.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/Urban_Fashion.png";
       hash = "sha256-nylkaZhQLT8HEsKztkAPq0JM/idtABPUiAmxrZXTFzc=";
     };
+    "animatediff-weighted_ipadapters-input1.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/animatediff-weighted_ipadapters-input1.png";
+      hash = "sha256-9z5n143sdVl4apjjWSt13esEa5QInrSJut/Uq73thrA=";
+    };
+    "animatediff-weighted_ipadapters-input2.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/animatediff-weighted_ipadapters-input2.png";
+      hash = "sha256-Ii/IwnhFlqjsK+k5PN8MhekoI8cPFYfTv8xFf+JEfhc=";
+    };
+    "animatediff-weighted_ipadapters-input3.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/animatediff-weighted_ipadapters-input3.png";
+      hash = "sha256-lTRRl6H1AYJSIKjxpP+GSB7lMfWROSe6GzaHORzNJEA=";
+    };
     "api_bfl_flux_1_kontext_max_image_style_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bfl_flux_1_kontext_max_image_style_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bfl_flux_1_kontext_max_image_style_ref.png";
       hash = "sha256-kNZd+gAmydTfqBcN5+pAwBXTYK+F1l4wEycJqe8Z7q0=";
     };
     "api_bfl_flux_1_kontext_multiple_images_input_dog.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bfl_flux_1_kontext_multiple_images_input_dog.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bfl_flux_1_kontext_multiple_images_input_dog.jpg";
       hash = "sha256-B+B07v14EWIhSpo1zfsYtY2ZdFlPbHV6Ic8CQBLzqF4=";
     };
     "api_bfl_flux_1_kontext_multiple_images_input_girl.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bfl_flux_1_kontext_multiple_images_input_girl.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bfl_flux_1_kontext_multiple_images_input_girl.jpg";
       hash = "sha256-UIwo5IeprbE6yEohGfFTgdaoOwHIBMWAyFz6WjG0ySc=";
     };
     "api_bfl_flux_1_kontext_multiple_images_input_sofa.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bfl_flux_1_kontext_multiple_images_input_sofa.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bfl_flux_1_kontext_multiple_images_input_sofa.jpg";
       hash = "sha256-DI4s+SUzOuvWW99gvY+cxS5gU7DKCm9qroZc/D2Qg/0=";
     };
     "api_bfl_flux_1_kontext_pro_image_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bfl_flux_1_kontext_pro_image_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bfl_flux_1_kontext_pro_image_input_image.png";
       hash = "sha256-z5Z8UX0GGMOogulkwSiWdOFNqMZHDyOvw8IDwgYVS9A=";
     };
     "api_bytedance_flf2v_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bytedance_flf2v_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bytedance_flf2v_first_frame.png";
       hash = "sha256-YbXKRG50HeSTyQ4cXCmbfE2h2sWx+tFDrQdXwJRzS28=";
     };
     "api_bytedance_flf2v_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bytedance_flf2v_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bytedance_flf2v_last_frame.png";
       hash = "sha256-rpJum+py5AUBjvALj+NIRHBHsQvhj6alN5RWtMdtBW4=";
     };
     "api_bytedance_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_bytedance_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_bytedance_image_to_video_input_image.png";
       hash = "sha256-z5TrGQ2Rr0HgbXTioEIPgUuDbz50+Uh9k8bsVPEQGpU=";
     };
     "api_elevenlabs_speech_to_speech.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_elevenlabs_speech_to_speech.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_elevenlabs_speech_to_speech.mp3";
       hash = "sha256-Wp8YhlzMJneChUpgU2WyHyiNo7721T0TME6cQoqicUI=";
     };
     "api_flux2_input_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_flux2_input_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_flux2_input_image_1.png";
       hash = "sha256-cUq+sJuG7kjgvjKpSoGBrStW/7+E4+aFmp8O7K4AS5A=";
     };
     "api_flux2_input_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_flux2_input_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_flux2_input_image_2.png";
       hash = "sha256-3mjFB2xVLRuCYXToUr1qFNYBNAJeqtlbxGC9kk+7suI=";
     };
     "api_flux2_input_image_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_flux2_input_image_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_flux2_input_image_3.png";
       hash = "sha256-ncdruDqm2vppQgrFcjuqY6s7Z4UINdnxnWpJw+IDcZo=";
     };
     "api_flux2_input_image_4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_flux2_input_image_4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_flux2_input_image_4.png";
       hash = "sha256-O4UiI8vJpCFd8iKa+Fj+cn6HQgr4JlCNg3rFZuhj8ww=";
     };
     "api_from_photo_2_miniature_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_from_photo_2_miniature_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_from_photo_2_miniature_input_image.png";
       hash = "sha256-NBU3XyOYMa6/p1LZmerKrlKmMctLg/8FbGuW+opECew=";
     };
     "api_hailuo_minimax_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_hailuo_minimax_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_hailuo_minimax_i2v_input_image.png";
       hash = "sha256-Wl2IXJ83VKoSb7+nmgqFDh3qQOIiczHlIkse6KYXZ94=";
     };
     "api_hailuo_minimax_video_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_hailuo_minimax_video_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_hailuo_minimax_video_first_frame.png";
       hash = "sha256-Ccwv+Qsoh2c3Mrl+zQkMMxCWf+v1FIA8IgI2lkbenG4=";
     };
     "api_kling_effects_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_kling_effects_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_kling_effects_input_image.png";
       hash = "sha256-CALDdXih977L9vxxFwslOAo7D1t8OWgmQVEtMZvzmdY=";
     };
     "api_kling_flf_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_kling_flf_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_kling_flf_first_frame.png";
       hash = "sha256-sed5uXIjgFC+xrPmXWQ1xWdywejn/ywaFMUHLuD2Qno=";
     };
     "api_kling_flf_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_kling_flf_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_kling_flf_last_frame.png";
       hash = "sha256-3PAZCNwJeHbbnVZKJr5p0NyNBommpQRgeoalIPK/VNo=";
     };
     "api_kling_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_kling_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_kling_i2v_input_image.png";
       hash = "sha256-5Ns97FtZeuzel8+v26QYIwukcWMvENSN6TecECPypl4=";
     };
     "api_kling_omni_edit_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_kling_omni_edit_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_kling_omni_edit_video_input_image.png";
       hash = "sha256-RBSQqdKEJ23xgdJEn9xvp2596DFONvO4uZedRX6IkZo=";
     };
     "api_kling_omni_edit_video_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_kling_omni_edit_video_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_kling_omni_edit_video_input_video.mp4";
       hash = "sha256-QcqDD59FRsa2Lr+6R6uMEG9pvx0uT+qvRb/2HelTeik=";
     };
     "api_ltxv_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_ltxv_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_ltxv_image_to_video_input_image.png";
       hash = "sha256-RMy/4N82ERXcwheuve9jdWYS2T7kOij4dIbdMSCtu0o=";
     };
     "api_luma_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_luma_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_luma_i2v_input_image.png";
       hash = "sha256-fTvwvjDSeohWQeBAt4Y3b7K4/Ufs/pTGD2lbh3BFlZg=";
     };
     "api_luma_photon_i2i_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_luma_photon_i2i_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_luma_photon_i2i_input_image.png";
       hash = "sha256-QVoS5yjUs594+vt6gX+lpuGHfeedryBhsoX8d9rUa/o=";
     };
     "api_luma_photon_i2i_ref_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_luma_photon_i2i_ref_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_luma_photon_i2i_ref_image_1.png";
       hash = "sha256-0pCfGHQUjUYbLs2ZLtFyNIE5dHwQ2EOBqZQNa/6ECoU=";
     };
     "api_luma_photon_i2i_ref_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_luma_photon_i2i_ref_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_luma_photon_i2i_ref_image_2.png";
       hash = "sha256-3nrEGDdZ3eKAlhlLKEYLsOj+JHTMFk8JZT2XL9oOWRU=";
     };
     "api_moonvalley_image_to_video_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_moonvalley_image_to_video_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_moonvalley_image_to_video_input_image.jpg";
       hash = "sha256-g+Tytx53vqiSK4cSCv7r7fs5aW/2ctRKFZZdN1utP58=";
     };
     "api_moonvalley_video_to_video_motion_transfer_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_moonvalley_video_to_video_motion_transfer_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_moonvalley_video_to_video_motion_transfer_input_video.mp4";
       hash = "sha256-7vAoYTJCiCXzvsXH4hbcA9IkiCLydOQDUowIH5uv6zc=";
     };
     "api_moonvalley_video_to_video_pose_control_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_moonvalley_video_to_video_pose_control_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_moonvalley_video_to_video_pose_control_input_video.mp4";
       hash = "sha256-HaHEpTDxmoNf6NsC56sxLqCMVfLQHXDBto6SWc6LMEw=";
     };
     "api_nano_banana_pro_input_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_nano_banana_pro_input_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_nano_banana_pro_input_image_1.png";
       hash = "sha256-xL+Ms7CmJWAeUJyeVkV2dPE3icOLAW8laOprFb7myX0=";
     };
     "api_nano_banana_pro_input_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_nano_banana_pro_input_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_nano_banana_pro_input_image_2.png";
       hash = "sha256-YV8dilDV7lX7ViyuEGof8Mdca+R5lLpHB9X/Ramul+Q=";
     };
     "api_openai_dall_e_2_inpaint_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_openai_dall_e_2_inpaint_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_openai_dall_e_2_inpaint_input_image.png";
       hash = "sha256-4r3Y2cqxOn35O8SQwyaT68I3GCPKWOjKi1YwGZyQo/I=";
     };
     "api_openai_image_1_hat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_openai_image_1_hat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_openai_image_1_hat.png";
       hash = "sha256-NWTThErUmUca/q40mrF9vG00aAUt7Y3sXF1l2EYVUKA=";
     };
     "api_openai_image_1_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_openai_image_1_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_openai_image_1_input_image.jpg";
       hash = "sha256-8MFj8yq5NjbG5iv5FLJNyX1mhBr4hh8JEbq289ZyYS4=";
     };
     "api_openai_image_1_input_image_mask.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_openai_image_1_input_image_mask.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_openai_image_1_input_image_mask.jpg";
       hash = "sha256-xzNopgjOS6rpgtzmAOEXOVdpbzTMG9bqAZhSwEHuIlc=";
     };
     "api_openai_sora_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_openai_sora_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_openai_sora_video_input_image.png";
       hash = "sha256-etVtOOYz9Z+1VJhzNQYh8O8cKmWE0bpx8EVENZJBzUY=";
     };
     "api_pika_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_pika_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_pika_i2v_input_image.png";
       hash = "sha256-ODFaeU3nO1Yt73Z7RSeVSI7HrvQnSkuJooCutPDEkIQ=";
     };
     "api_pika_scene_ref_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_pika_scene_ref_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_pika_scene_ref_image_1.png";
       hash = "sha256-aalWv2G+aS5yhCxeuU8NwqfnR0fPQEY0qTnTBnbKKAo=";
     };
     "api_pika_scene_ref_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_pika_scene_ref_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_pika_scene_ref_image_2.png";
       hash = "sha256-rheGEjYnr/XwP4gBUfbHL173zny6j3QuZn1mT07vEio=";
     };
     "api_pixverse_template_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_pixverse_template_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_pixverse_template_i2v_input_image.png";
       hash = "sha256-SvQUZtUi7cZaTmD/THQa/ujGc/XIjtY88R6MQvtaYLw=";
     };
     "api_rodin_gen2_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_rodin_gen2_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_rodin_gen2_input_image.png";
       hash = "sha256-vGFcKPZwOvOWA0Dy2i/BQl8WM1awzophp/CoddPjkKc=";
     };
     "api_rodin_image_to_model_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_rodin_image_to_model_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_rodin_image_to_model_input_image.png";
       hash = "sha256-/Lmlt8XHCBDgE40OtPBzD2nDbsr/yo7K22B+45ceU3s=";
     };
     "api_rodin_multiview_to_model_back.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_rodin_multiview_to_model_back.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_rodin_multiview_to_model_back.jpg";
       hash = "sha256-wqQMr9xUo6IssmvnGG5Y6C+tnZec5wjLFJvQSPDWQkE=";
     };
     "api_rodin_multiview_to_model_front.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_rodin_multiview_to_model_front.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_rodin_multiview_to_model_front.jpg";
       hash = "sha256-SFIMrl7IPA54je8dE/JfRRryt26/B+iCbWkwqxI4ORw=";
     };
     "api_rodin_multiview_to_model_left.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_rodin_multiview_to_model_left.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_rodin_multiview_to_model_left.jpg";
       hash = "sha256-hycgIV7pqk2nuvqF0947VyR0gD4J2zX+GyiEz1scCio=";
     };
     "api_runway_first_last_frame_first_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_runway_first_last_frame_first_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_runway_first_last_frame_first_frame.jpg";
       hash = "sha256-oCnSvvoQS9FL1GJXw6PPcjvC2BLeQTHhEb6ZOjGoJ7g=";
     };
     "api_runway_first_last_frame_last_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_runway_first_last_frame_last_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_runway_first_last_frame_last_frame.jpg";
       hash = "sha256-EF7JNm833S9HWOPPlJ+zi+8o63vRbOOMf9VdRb82iaw=";
     };
     "api_runway_gen3a_turbo_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_runway_gen3a_turbo_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_runway_gen3a_turbo_image_to_video_input_image.png";
       hash = "sha256-tJTitqMYwIbPGwWFjYgLi4RIwxU2Cyd9Dnc7JvuL4Cw=";
     };
     "api_runway_gen4_turo_image_to_video_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_runway_gen4_turo_image_to_video_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_runway_gen4_turo_image_to_video_input_image.jpg";
       hash = "sha256-RkouDCAmS+8x2VEHXr2FpJIEDfsiqHFB9GyzrDdakxE=";
     };
     "api_runway_reference_to_image_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_runway_reference_to_image_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_runway_reference_to_image_input_image.png";
       hash = "sha256-GNcouMimGoYv4MYLpyAH1eeuXRUYJjEMteNhU1UCn48=";
     };
     "api_stability_ai_audio_inpaint_input_audio.wav" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_stability_ai_audio_inpaint_input_audio.wav";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_stability_ai_audio_inpaint_input_audio.wav";
       hash = "sha256-CASfQv80I5A+63+dRq43PIgTZ1bu3sjFvfZXBFgdQPE=";
     };
     "api_stability_ai_audio_to_audio_input_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_stability_ai_audio_to_audio_input_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_stability_ai_audio_to_audio_input_audio.mp3";
       hash = "sha256-Xa5F7M/MckniFg5EsUvCjCJoyibmQj9n3P3Uhtv2XQA=";
     };
     "api_stability_ai_i2i_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_stability_ai_i2i_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_stability_ai_i2i_input_image.jpg";
       hash = "sha256-DeXsVuFAHdXdu2c+j37NrTlGrgFY94G3orWMzCUVsUw=";
     };
     "api_stability_ai_sd3.5_i2i_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_stability_ai_sd3.5_i2i_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_stability_ai_sd3.5_i2i_input_image.jpg";
       hash = "sha256-VkA5QYKb4HE5HCcEVKq8l2N0JfeNPhgIFl3tpPrcLVQ=";
     };
     "api_topaz_image_enhance_input_image.webp" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_topaz_image_enhance_input_image.webp";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_topaz_image_enhance_input_image.webp";
       hash = "sha256-acTP47zK+mzpKoyyx6rJYhHnyUnOhvoj7oX6yAu7v3k=";
     };
     "api_topaz_video_enhance_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_topaz_video_enhance_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_topaz_video_enhance_input_video.mp4";
       hash = "sha256-BDFw2mgCwJx5wF5DrDe+42F505UNZFdDfeGMZRlyAh4=";
     };
     "api_tripo_image_to_model_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_tripo_image_to_model_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_tripo_image_to_model_input_image.jpg";
       hash = "sha256-gxzU+8pr1D0EtdnN97rSV/2UThUdt4QeNP/fBFEuc1I=";
     };
     "api_tripo_multiview_to_model_back_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_tripo_multiview_to_model_back_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_tripo_multiview_to_model_back_image.jpg";
       hash = "sha256-wv6TQLYSeGL4pjikvdeODAUcRot1wOt17c+4RgFhqDo=";
     };
     "api_tripo_multiview_to_model_front_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_tripo_multiview_to_model_front_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_tripo_multiview_to_model_front_image.jpg";
       hash = "sha256-mM43dcyybQQ932wc/uqoCmt1tLQxz0k8BiyIzX9EpK8=";
     };
     "api_veo2_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_veo2_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_veo2_i2v_input_image.png";
       hash = "sha256-Menr+nqMIwiKhy+9InVSQkdy6KFCfJV/Bkev+pQ7Id0=";
     };
     "api_veo3_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_veo3_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_veo3_input_image.png";
       hash = "sha256-pCUoMBkxy5noLu81ftizeaWL2kKALJppJopxXWgI3bY=";
     };
     "api_vidu_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_image_to_video_input_image.png";
       hash = "sha256-CtM1LgYT5D4/E0ZHQ3QWhwcCMXXi9Og4iHFsFWPnx4k=";
     };
     "api_vidu_q2_r2v_red_haired_girl.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_q2_r2v_red_haired_girl.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_q2_r2v_red_haired_girl.jpg";
       hash = "sha256-Ld949sGP6V+SHdx8z4z2/9MxbSf+ji0vK9bfxHcMy9w=";
     };
     "api_vidu_reference_to_video_reference_image_1.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_reference_to_video_reference_image_1.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_reference_to_video_reference_image_1.jpg";
       hash = "sha256-d16kaTDCHVzL6moAbVGd+OZYyyKHv6pRt+AgAE4YKwQ=";
     };
     "api_vidu_reference_to_video_reference_image_2.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_reference_to_video_reference_image_2.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_reference_to_video_reference_image_2.jpg";
       hash = "sha256-bHx2mDe3etuFoKZox81S1HJZ5cuvf0AzRodShJnvRwQ=";
     };
     "api_vidu_reference_to_video_reference_image_3.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_reference_to_video_reference_image_3.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_reference_to_video_reference_image_3.jpg";
       hash = "sha256-e5QLQ4kt0FieWwAmtx+zIcRgx+oRfMx2lO4mt0SBuDI=";
     };
     "api_vidu_start_end_to_video_last_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_start_end_to_video_last_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_start_end_to_video_last_frame.jpg";
       hash = "sha256-tITHRN2XKBxK4vAaSwm9zhRSopo78vZxHaWdLNzO8ks=";
     };
     "api_vidu_start_end_to_video_start_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_vidu_start_end_to_video_start_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_vidu_start_end_to_video_start_frame.jpg";
       hash = "sha256-2TiUfe+QZeH9JegKxsmn1CsrQB3L5e64U+yW9VtCka8=";
     };
     "api_wan_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/api_wan_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/api_wan_image_to_video_input_image.png";
       hash = "sha256-JrksHkqmdNmuFvtcmjz6xDzsyQpNkckrjCauC1ZpBx0=";
     };
     "armored_warrior.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/armored_warrior.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/armored_warrior.mp4";
       hash = "sha256-FtXxfb9fMa66d+oFojVrU0ET79scTddyppA/181egwQ=";
     };
     "audio_ace_step_1_m2m_editing_input_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/audio_ace_step_1_m2m_editing_input_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/audio_ace_step_1_m2m_editing_input_audio.mp3";
       hash = "sha256-VY9O3l8XxVeWAFJhr+fJy8j9VmUqWoE4zAfXm0HEOa0=";
     };
     "audio_speaker1_woman.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/audio_speaker1_woman.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/audio_speaker1_woman.mp3";
       hash = "sha256-0AhJSXbjSwUQjxgZQqbUNj4r8RduurwQ7LadLmEkWvs=";
     };
     "audio_speaker2_man.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/audio_speaker2_man.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/audio_speaker2_man.mp3";
       hash = "sha256-YyrstFOppY03+fnnDQf2dIq2BK9ZpWS4TrdgMUQNNUU=";
     };
     "baby_otter.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/baby_otter.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/baby_otter.png";
       hash = "sha256-Gu/PIxjXXybynlqiEBuMfhpc0ByFkO3qTi+id5GhyKo=";
     };
     "billboard.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/billboard.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/billboard.png";
       hash = "sha256-Q4OjXIRPXei1Ny5o57/Vacgy63srihBDtzg5Vb7DtzU=";
     };
     "black_coat_model.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/black_coat_model.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/black_coat_model.png";
       hash = "sha256-q4P8AS08lpOUte9f+3sInyd5i6XkWUTa2/vS7p9PNI0=";
     };
     "blue_shirt_rabbit.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/blue_shirt_rabbit.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/blue_shirt_rabbit.jpg";
       hash = "sha256-hZg5zpKj0UTtHv9wZGzyp/tQtRMvI5BPcIlb00kkqdQ=";
     };
     "blue_tone_woman.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/blue_tone_woman.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/blue_tone_woman.png";
       hash = "sha256-KfjST3Ks9fCEuvRaI8fUw8LRe64QALjAJVQlDeqmEu8=";
     };
     "bold_outfit_woman.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/bold_outfit_woman.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/bold_outfit_woman.jpeg";
       hash = "sha256-HT3cIt+vLhL8M2CmMdSqIa98QyU8sDfdKN211mxD+fU=";
     };
     "boxing.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/boxing.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/boxing.png";
       hash = "sha256-PBoa28r2eMEHj0U28pd9VT31xK0iS8KKXs556zWKBnM=";
     };
     "boxing_man.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/boxing_man.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/boxing_man.mp4";
       hash = "sha256-WpNI2slNhVQ7RY9ivLzhH52EdOkyIae631WnoVRYk+M=";
     };
     "brown_moisturizer_bottle.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/brown_moisturizer_bottle.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/brown_moisturizer_bottle.jpg";
       hash = "sha256-0r/0gGCoiBqbmFY4uug46xhbw8xeZ2+GqZ5AKoc9Xr8=";
     };
     "butterfly_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/butterfly_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/butterfly_girl.png";
       hash = "sha256-4VEYt8Ul6JSd1MWFS0jKztzNLzPp66G470QlHymdPWU=";
     };
+    "cactus_man.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/cactus_man.png";
+      hash = "sha256-9tevEHEDH8GZHRuRZfdXWMQavptWnnQo9WLfsD8/naw=";
+    };
     "car_interior_white.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/car_interior_white.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/car_interior_white.jpeg";
       hash = "sha256-i2rGGeWYF6zJ2n8iRhBTIvbYGn0KHpcXiV4pczdNhVU=";
     };
     "cartier-glasses-1.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/cartier-glasses-1.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/cartier-glasses-1.jpg";
       hash = "sha256-iMHGJy7ZV7UTm7wM3BTu9EcHpmmFy3pb5SKDTA84hss=";
     };
+    "casual_male_portrait.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/casual_male_portrait.png";
+      hash = "sha256-91De1Pp9NZUQuG0pc8MwkSOMAfCJ8tZ/YZg4sQUaAtA=";
+    };
     "character-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/character-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/character-1.png";
       hash = "sha256-tibzr35+Jbq4hBdWXaUkqolpsNlQ/3eAvAoR/SaMxrA=";
     };
     "character_in_red_jacket.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/character_in_red_jacket.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/character_in_red_jacket.png";
       hash = "sha256-Fyhe0t5UpYosSCpX59mWGx+PorXQmGz4aFjW5bSn+cc=";
     };
     "character_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/character_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/character_input.png";
       hash = "sha256-2J8OxMo3fuHICQOuYX+sMR/6ITjA7hIL4jBArxLCDN4=";
     };
     "chasing_the_light.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/chasing_the_light.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/chasing_the_light.png";
       hash = "sha256-ZsUfDOf8/a5pRLOGb3KgyyH5+SGwXCnFzuoCw4bLar8=";
     };
     "chatterbox_input_gettysburg.wav" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/chatterbox_input_gettysburg.wav";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/chatterbox_input_gettysburg.wav";
       hash = "sha256-2o9PO0PvcG2oFpeZ/XOi0LCnTmHPE9mEZkoPswvtN0c=";
     };
     "chatterbox_input_target_voice.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/chatterbox_input_target_voice.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/chatterbox_input_target_voice.mp3";
       hash = "sha256-vSeMxqKwZUtV6srFdDuoboQ187PZiQe0CTOrpfbFG6c=";
     };
     "close_up_girl_skin.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/close_up_girl_skin.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/close_up_girl_skin.png";
       hash = "sha256-CtvuOSWJAKBG7W2NPrX+RHB6yat3dUPAuw5dg1lXAJw=";
     };
+    "clothing.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/clothing.png";
+      hash = "sha256-h/1BqdNdDbNquDyXH4mRed1eU6liCG02mfGj297d0Sw=";
+    };
     "coastal_smiling_woman.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/coastal_smiling_woman.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/coastal_smiling_woman.png";
       hash = "sha256-14uy/od1MZOOWWAmyzxXf/evcYjLkR6ixvScHa9i0XQ=";
     };
     "comfy_billboard.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_billboard.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_billboard.png";
       hash = "sha256-D1+N++9od6L8MZNOPbKms1HEA77Hevo9o5Pc0ip30Ao=";
     };
     "comfy_cloud_bottle.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_cloud_bottle.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_cloud_bottle.png";
       hash = "sha256-xW/746mZxVEYirZQ15NiAthjzYWAdN6RPFt617VoSaI=";
     };
     "comfy_cloud_water_can.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_cloud_water_can.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_cloud_water_can.jpg";
       hash = "sha256-Ja2etAUFP25K/czxV9BQwWz1KjXr2Soosc/JVIIehjs=";
     };
     "comfy_gpu.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_gpu.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_gpu.png";
       hash = "sha256-rP2wI2XdRUCMZcS/r/wud7mdZR8KKB+CtIqhRw6g9Bc=";
     };
+    "comfy_gpu_angled.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_gpu_angled.png";
+      hash = "sha256-P6rgnbl/XLTahNs6gtv9JN3V8QbLJt7Dwkf0Y1VDxiA=";
+    };
+    "comfy_gpu_close_up.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_gpu_close_up.png";
+      hash = "sha256-t3a8ZMW1uOW8BmAxzsmOJjU7CmQioeZWgnrVaLncDL0=";
+    };
+    "comfy_gpu_flat.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_gpu_flat.png";
+      hash = "sha256-XsB11GMRRGaItBFvI+YNvSM2uYBlgFqj7Nv+nqmKCMg=";
+    };
+    "comfy_hat.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_hat.png";
+      hash = "sha256-JX0Z6x1K1+kiX+Mdj2WmKO2uYOobeEbqpPA441QyVsc=";
+    };
     "comfy_logo_b.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_logo_b.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_logo_b.png";
       hash = "sha256-RGQx12jKKENhxZYJ7e1qsKHzfRVrmATVeGWA1fRDD6E=";
     };
     "comfy_logo_blue.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_logo_blue.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_logo_blue.png";
       hash = "sha256-OStPixbTqhl3gfkVl2gZBcEyDjd7DYGvUwyHZAsES/Y=";
     };
     "comfy_logo_c.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_logo_c.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_logo_c.png";
       hash = "sha256-J0rO0sotqTs50beA052IxaPhTlTD2rgZAnfwnmq+8c0=";
     };
     "comfy_shampoo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_shampoo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_shampoo.png";
       hash = "sha256-PK2yNZFdVLktD9rrLAUH5eBbq6CCfgqkXDGNjR+EmPY=";
     };
     "comfy_sofa.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfy_sofa.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfy_sofa.png";
       hash = "sha256-XtGj0LS1D6tjTLj4pD6kYXK+KlsDJA2i0eV+i+aJz/A=";
     };
     "comfyorg_logo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfyorg_logo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfyorg_logo.png";
       hash = "sha256-9l4Tn0PtOehfzldBoBQ9xQvHoSODmQM3P+Ucljn6QR0=";
     };
     "comfyui_logo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/comfyui_logo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/comfyui_logo.png";
       hash = "sha256-vCgOZHgXOc8C65tfKRzuF20x4dNVWOHhNQGqMnp05YE=";
     };
     "controlnet_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/controlnet_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/controlnet_example_input_image.png";
       hash = "sha256-qxT2K8sdwcQeQ5dq7E9F3z2QldoxLjENARRUiGbNwL8=";
     };
     "cozy_bear.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/cozy_bear.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/cozy_bear.jpg";
       hash = "sha256-K7OvRWDdF8JobLqHt9VZS4dhd3wAxOBEKDbJ16O5EeI=";
     };
     "crystal_flower.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/crystal_flower.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/crystal_flower.png";
       hash = "sha256-7DNzVKjWG81hT9YzkeIVZBdO0/9waGRooJ4qbMgxb3A=";
     };
     "cube_robot.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/cube_robot.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/cube_robot.jpg";
       hash = "sha256-RXJuM6YKV2WQoLhAcAR+yBaQy6S6LatpizZXpd0EPUo=";
     };
     "cyber_genesis.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/cyber_genesis.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/cyber_genesis.png";
       hash = "sha256-rSOwIGFTlJ0FxNZx7iLPOAASmdl9yLc9PrqW6XexQX8=";
     };
     "cyberpunk_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/cyberpunk_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/cyberpunk_robot.png";
       hash = "sha256-8hFk4RdYBtRY45oeBs2oVGFF1mkRk2JLfFfckZlcPCg=";
     };
     "dad_carry_daughter.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/dad_carry_daughter.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dad_carry_daughter.mp4";
       hash = "sha256-yU9Oi+S5qCkOGFPBS4u2MYCVUJN1+BmQX2NKCHyK2VU=";
     };
     "dancer.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/dancer.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dancer.png";
       hash = "sha256-G6a6lmb2e8XsyrDDVF5iNm5y4WNlcpm5KTS6vpN3anA=";
     };
     "dancing_capybara.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/dancing_capybara.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dancing_capybara.png";
       hash = "sha256-kpHKJMDc/rbVsGu/GHiGG6zN2XDd3WZrXtnS1pwHDOY=";
     };
     "dancing_women.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/dancing_women.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dancing_women.mp4";
       hash = "sha256-Is80Ztdy/8y6+gsWKgGAdbl2sKH8mkljUO/Y+n8UO38=";
     };
     "deep_curl_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/deep_curl_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/deep_curl_portrait.png";
       hash = "sha256-WqPdXW23nbTT1iqfPko2XqCJeIwu7jW+9dOvDcn6ZgM=";
     };
     "denim_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/denim_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/denim_girl.png";
       hash = "sha256-X68wNXAtJp1NHT97nsPvKY0TaBmFW89DF6SdzsBmZvI=";
     };
     "depth_controlnet_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/depth_controlnet_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/depth_controlnet_input_image.png";
       hash = "sha256-yhSAsCr8qnfZfCCOXMK3LCJH8teSe+xTaLG9sliER9k=";
     };
     "depth_t2i_adapter_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/depth_t2i_adapter_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/depth_t2i_adapter_input_image.png";
       hash = "sha256-PnVrZNMnu0vsQiqbGoIS4XewZDZ7xe7G0g4uXWU1wB0=";
     };
     "dieline.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/dieline.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dieline.jpg";
       hash = "sha256-BZ2FGcLQGVbAEHpmLbi2OeLfeJAW8iMmv9Fua6K8Vbg=";
     };
     "dj_capybara.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/dj_capybara.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dj_capybara.png";
       hash = "sha256-AiDJwp7vA3hHM6r5g/Maq4Sni5XMHDQ5jhKfvV/7Jfs=";
     };
     "downhill_run.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/downhill_run.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/downhill_run.jpg";
       hash = "sha256-jLOS0/6MpeCqinGweldPjk2WB96KQoyr498lQHf+QfQ=";
     };
+    "dragon_fruit.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/dragon_fruit.png";
+      hash = "sha256-1fz0gCYZEuTLPa02IM1ttcXAKbrhZ7lcKdUsUBynesI=";
+    };
     "egyptian_queen.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/egyptian_queen.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/egyptian_queen.png";
       hash = "sha256-yikANilHBmSbYGzxqbFM6/WFPqyZS7SKecYqSVGrFEA=";
     };
     "example.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/example.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/example.png";
       hash = "sha256-qOIVrTKgBS/EGQ6cWGNCjV7jXNmLJGJDhCuoNgURt8Q=";
     };
     "fighter_jet.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/fighter_jet.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/fighter_jet.png";
       hash = "sha256-Kly/QejnnOsemlp5yNdd/xUR/NXZbmIcJSz/Q4a4TY8=";
     };
+    "flower.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flower.mp4";
+      hash = "sha256-2cm2saouM5Mw8AgOEqyv78dzPRNry0sVMU33eNwStPQ=";
+    };
     "flower_sea.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flower_sea.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flower_sea.png";
       hash = "sha256-o/emLVJnZcS2Q8gqP6NrGrf2cSCMg45+QV9XNNokv/0=";
     };
     "fluffy_beige_sofa.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/fluffy_beige_sofa.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/fluffy_beige_sofa.png";
       hash = "sha256-WjpMUPxJJsGrel0z4uXcU2zZvfM6O3aaIzVhzDUoD04=";
     };
     "flux1_dev_uso_reference_image_gen_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux1_dev_uso_reference_image_gen_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux1_dev_uso_reference_image_gen_input_image.png";
       hash = "sha256-FPypwQhXMqDkTG6wqD2Xgbnz9mKnX+wLUMo0hjGhpJM=";
     };
     "flux_canny_model_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_canny_model_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_canny_model_example_input_image.png";
       hash = "sha256-a9GwG+npz1E9XefM2DvLkuU8+XtWh+32rwbkD6N54iE=";
     };
     "flux_depth_lora_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_depth_lora_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_depth_lora_example_input_image.png";
       hash = "sha256-ZV3BR6VEpuXYCLwNxHDUMLxZUkuKPvoNrwiHCGnmMqc=";
     };
     "flux_fill_inpaint_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_fill_inpaint_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_fill_inpaint_example_input_image.png";
       hash = "sha256-PPbMCWDfXVn3mgcFfrcye4eeNvgHyDrxsi/STtO35/g=";
     };
     "flux_fill_outpaint_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_fill_outpaint_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_fill_outpaint_example_input_image.png";
       hash = "sha256-QnnAnLLBzauSBGIshzVm75jd5B5h1gktO/8noWAWiPA=";
     };
     "flux_kontext_dev_basic_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_kontext_dev_basic_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_kontext_dev_basic_input_image.jpg";
       hash = "sha256-0oTft7YLQaIzgdBd1ad3WAeC+Unzdo1RoC9ouWSYiV4=";
     };
     "flux_redux_model_example_reference_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_redux_model_example_reference_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_redux_model_example_reference_image_1.png";
       hash = "sha256-tZ5as16Ak0wmUmBz5Hrqof3Wgn4iNb5+DBwCnuHbrP0=";
     };
     "flux_redux_model_example_reference_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/flux_redux_model_example_reference_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/flux_redux_model_example_reference_image_2.png";
       hash = "sha256-dbx2RFiJnQ8vjLgVXkjdvKLP6Mgv/Sj711aXQ7nVn7k=";
     };
     "forest_background.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/forest_background.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/forest_background.jpg";
       hash = "sha256-cz6RWAVnijOR8c+zxtNoca1L3+VIFQWbyGE7mzI5jb4=";
     };
     "frame_interpolation-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/frame_interpolation-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/frame_interpolation-input.mp4";
       hash = "sha256-RZQE3/9F4SVnh+mTBKu+XXuAgqsH7nVj3xM+WCjG98Q=";
     };
     "freckled_curly_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/freckled_curly_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/freckled_curly_girl.png";
       hash = "sha256-Qh3rE+6eKr1olayn78YhGfxjhV4pMfsIgrajXSkDoBc=";
     };
     "furry_ball.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/furry_ball.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/furry_ball.png";
       hash = "sha256-BdLS4OFmmxrL40pO5vpxwG0hHcmoeH93SBNK8X6VFpc=";
     };
     "furry_tech.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/furry_tech.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/furry_tech.png";
       hash = "sha256-F/9bE/viDPJ1+1AYPGtlVOnDjwsUe7a3To7xHQVCiso=";
     };
     "future_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/future_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/future_portrait.png";
       hash = "sha256-jBngZrCQd+EmC5N463WVmh5Ac7I/0hu0nupjNJdhKok=";
     };
     "future_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/future_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/future_robot.png";
       hash = "sha256-ew4aCVUkg7F/oG2lrVin116Ja81DoKB3znDa7VJktIQ=";
     };
     "futuristic_motorcycle.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/futuristic_motorcycle.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/futuristic_motorcycle.mp4";
       hash = "sha256-QlJsLxGO6FVNxZILzHiFvf2BsVcWEPVclQaWKsRDwU4=";
     };
     "game_style.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/game_style.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/game_style.png";
       hash = "sha256-mYf5QqNqaT5S03oDAUQw+7TpNToYeGa8Y/R7+I/7H70=";
     };
     "gan_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gan_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gan_input.mp4";
       hash = "sha256-IO0LjxuIvI8GbiOS6GTWhRt5KfBWQd5SeNiCMuCvgWw=";
     };
     "gas_lamp.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gas_lamp.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gas_lamp.png";
       hash = "sha256-BRdddRFSXYwoiAhKPkD6nnom8rZ7LUAupIyhtIqulZo=";
     };
     "giant_trees_sky_pyramid.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/giant_trees_sky_pyramid.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/giant_trees_sky_pyramid.png";
       hash = "sha256-WDx1p80jZcUMQ04+Wh7BRdEm5Ncpe7303ZOxYC6/Ilg=";
     };
     "girl_riding_unicorn.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/girl_riding_unicorn.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/girl_riding_unicorn.png";
       hash = "sha256-VI7gUuqOW+HGpzGLxL0AtlczbaOZ84qAGE/qA8gxc2g=";
     };
     "goldenfish_in_bag.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/goldenfish_in_bag.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/goldenfish_in_bag.png";
       hash = "sha256-mdDvP+m7xDMN8HCpHA8k0q6MF/yuuc82csL83UEQbVM=";
     };
+    "golf_ball_in_crocodile_mouth.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/golf_ball_in_crocodile_mouth.png";
+      hash = "sha256-3b3837M4kd5PUmDlrpYYmfasELNXP83GYsrBzfRJ+9Y=";
+    };
     "gs2_image1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gs2_image1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gs2_image1.png";
       hash = "sha256-IB16G+xa4LccN3xd+QKcTJRd9D+kWcUssLXL0UYGm7U=";
     };
     "gs2_image2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gs2_image2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gs2_image2.png";
       hash = "sha256-q4XSECXByl+S3DsOd2uPCTabSjBfMQ9rafRMT1Bctyo=";
     };
     "gs2_image3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gs2_image3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gs2_image3.png";
       hash = "sha256-2BTtJBRxDdB1QvM/+0shmGxGQKKpXzQE04nZ9QJCjjA=";
     };
     "gs2_image4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gs2_image4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gs2_image4.png";
       hash = "sha256-FxB1tbII8Xna7QVa5234wxhAGE12QNuTkZ2HZAv0hNI=";
     };
     "gsc3_car.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gsc3_car.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gsc3_car.jpeg";
       hash = "sha256-UnGgMH/6NcpJeiG/tsIxYaKwIcRBlxiYyDIRXYfbrWs=";
     };
     "gsc3_landscape.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gsc3_landscape.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gsc3_landscape.png";
       hash = "sha256-sxQXSUCXtm6AsppTe9CTeDXIkixj7B7nd+lEq6Yn2gg=";
     };
     "gsc_creator_2_2_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/gsc_creator_2_2_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/gsc_creator_2_2_input.png";
       hash = "sha256-mBk5dPLHPOJWL6HCORNVDCmAsy0C09RmQYXHc1cB0PU=";
     };
     "handbag_white.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/handbag_white.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/handbag_white.png";
       hash = "sha256-037DHurwaDLvWbCUjN16wJpbyWqVFhTFIH/BLmRuStQ=";
     };
     "hidream_e1_1_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/hidream_e1_1_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/hidream_e1_1_input_image.jpg";
       hash = "sha256-cThRWI8GzJ7fL+0uDL/aRJTnb494dM1COfE/wX2sSbo=";
     };
     "hidream_e1_full_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/hidream_e1_full_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/hidream_e1_full_input_image.jpg";
       hash = "sha256-lf/N/sx0xmNRRnz5xMQunOHywyDzL9XvvNvqUzFNwto=";
     };
+    "high_view_classic_car.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/high_view_classic_car.png";
+      hash = "sha256-4cRJ8smTEb2yTaN9UgFnMTQZgvc57q4EIoQ3o8caKF4=";
+    };
     "hk_scene.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/hk_scene.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/hk_scene.png";
       hash = "sha256-wQZQN75OtCCz5bqfyuvCzmbddeE5DCWkAQM8NuK8Wl4=";
     };
     "horse_running.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/horse_running.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/horse_running.mp4";
       hash = "sha256-Ece2+rEFbRV3oBUAdbTYAPnLt4jzaQzAzUq3PZGtTJw=";
     };
     "hovering_figure.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/hovering_figure.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/hovering_figure.png";
       hash = "sha256-KNFCklZid1k6KCQwzOeavYyaMdGWu5geAeJKd9touSo=";
     };
+    "iced_drink_cup.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/iced_drink_cup.png";
+      hash = "sha256-aCk6FigThXyyBbxREaf2fR9BuhbqRl8I72Qdo730PNo=";
+    };
     "illustration_bw.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/illustration_bw.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/illustration_bw.png";
       hash = "sha256-t0VmjaXKl0ukTNcwROy+DwWY3DsgBXZxzjnZNNyP8ng=";
     };
     "image2image_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image2image_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image2image_input_image.jpg";
       hash = "sha256-9StBf+r36LZbMYdenOvb+r74JK7Lvgs6mA+LVRum1SA=";
     };
     "image_chrono_edit_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_chrono_edit_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_chrono_edit_input_image.png";
       hash = "sha256-OXE6zsf66cinQLyRsubKO1N0wQC4weCuMobeRcO92v8=";
     };
     "image_flux.1_fill_dev_OneReward_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_flux.1_fill_dev_OneReward_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_flux.1_fill_dev_OneReward_input_image.png";
       hash = "sha256-VevagyeOEy6KTj1FXeZQaLAokmjxXn/szTQJZECgzco=";
     };
     "image_flux2_input_Illustration.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_flux2_input_Illustration.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_flux2_input_Illustration.png";
       hash = "sha256-QKuCevU6PQqN714POZUMr3+IkGxyuXx30anTDhPsm4A=";
     };
     "image_flux2_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_flux2_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_flux2_input_image.png";
       hash = "sha256-/kFtfPQIUG9uSKiKtT6/xh6hNSoU29F4fRwh1XS++4g=";
     };
     "image_flux2_input_ref_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_flux2_input_ref_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_flux2_input_ref_image.png";
       hash = "sha256-PraK9GGrUC3+ADi0ccgusvVc6EQgzprbLsIBhzWrlBY=";
     };
     "image_lotus_depth_v1_1_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_lotus_depth_v1_1_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_lotus_depth_v1_1_input_image.png";
       hash = "sha256-bVKPtGnLgpnVQN14qMTzK1dMDLPdDeGkgpyMLx8tFec=";
     };
     "image_omnigen2_image_edit_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_omnigen2_image_edit_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_omnigen2_image_edit_input_image.png";
       hash = "sha256-Jk2cH+rfO9v2KLDVd/paq/AAioZBXkPZcFYU43O2oUI=";
     };
     "image_qwen_image_controlnet_patch_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_controlnet_patch_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_controlnet_patch_input_image.png";
       hash = "sha256-XNO5EDIGeHcqvBbQjjx3wjLA8O4pJAOTkov5TlEr3cU=";
     };
     "image_qwen_image_edit_2509_input_image-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_edit_2509_input_image-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_edit_2509_input_image-2.png";
       hash = "sha256-0ZyfQ8IOOP8u2T/Lag9TAl30SHDG2b5bSdVo+iO6YRc=";
     };
     "image_qwen_image_edit_2509_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_edit_2509_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_edit_2509_input_image.png";
       hash = "sha256-Nx2TvRp5fdhyeWKD11PC3wtNCIBRXFycEhP0gOOBJ54=";
     };
     "image_qwen_image_edit_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_edit_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_edit_input_image.png";
       hash = "sha256-aqYPFkzu8fuE1ldioLNDrcekEbwsYcKXCm4G5xMF9ZI=";
     };
     "image_qwen_image_instantx_controlnet_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_instantx_controlnet_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_instantx_controlnet_input_image.jpg";
       hash = "sha256-2q/Xf4GDbPA517SdC2npZ6l0CWfPUS2gzVtwBjsuRr0=";
     };
     "image_qwen_image_instantx_inpainting_controlnet_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_instantx_inpainting_controlnet_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_instantx_inpainting_controlnet_input_image.png";
       hash = "sha256-uNkkGduAwNDoNfLLlx6lQvY88t/TCrN7AFWDrJyL5LA=";
     };
     "image_qwen_image_union_control_lora_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_qwen_image_union_control_lora_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_qwen_image_union_control_lora_input_image.png";
       hash = "sha256-S1L0dxDtt6XrFAOnqQ9wHSFhSifRMpNGJLGIk7YfjLs=";
     };
     "image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_to_video_input_image.png";
       hash = "sha256-cq5bJlp8d51WujZCep5zo1QenPmR7GLNFIdUqAlc9mg=";
     };
     "image_to_video_wan_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_to_video_wan_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_to_video_wan_start_image.png";
       hash = "sha256-1eOIKrmnAeFd4cZ6ibhZxxsjh8T7wTJXJPUgPqTokDc=";
     };
     "image_z_image_turbo_fun_union_controlnet_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/image_z_image_turbo_fun_union_controlnet_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/image_z_image_turbo_fun_union_controlnet_input_image.png";
       hash = "sha256-OHnVIKNCkTBID+5jaiYcp0PGmQdu4USsIoJObiY2+Bg=";
     };
     "inflated_character.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/inflated_character.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/inflated_character.png";
       hash = "sha256-fD0JAh7fRpMZD3/mwzi5By4haWmvWtFpu+ch3SX69sQ=";
     };
     "inflation_lora_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/inflation_lora_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/inflation_lora_input.png";
       hash = "sha256-Auwr/0aha/OTV8LwjiDM+eA1fThxoo3AmQC90WPwijg=";
     };
     "inpaint_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/inpaint_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/inpaint_example_input_image.png";
       hash = "sha256-678kJVt5kHyQ/mkmlu6kH9vpgi1LvIrg9mAHnwqbRVk=";
     };
     "inpaint_model_outpainting_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/inpaint_model_outpainting_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/inpaint_model_outpainting_input_image.png";
       hash = "sha256-Oz2LO18bGvy8PIGeixO1o4WTkXDMEz2/yk8qIULkEDc=";
     };
+    "input-aspect-ratio-converter" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input-aspect-ratio-converter";
+      hash = "sha256-vVclgK9BlR91hEe0lL2UB1h66ybzdKuTc4qHzddFcAQ=";
+    };
+    "input-illustration_to_real-1.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input-illustration_to_real-1.png";
+      hash = "sha256-gcwfFL8PH9KTW+FyYkS46Prf76c8jzYeVQNGp+6BXrk=";
+    };
     "input-sprite-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input-sprite-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input-sprite-1.png";
       hash = "sha256-vfs+g8j6vA7OJcjktznX85uljneWJnJojfLtPt1O+c4=";
     };
+    "input_1-relight.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_1-relight.png";
+      hash = "sha256-mBabM/L24uWZCCZAhVCILjNkxhwR8y/Zkx6I6XZ3wWk=";
+    };
+    "input_2-relight.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_2-relight.png";
+      hash = "sha256-FHHEYd5cd8AeXquuDZ1D1hwZShcEAyDNVq7vepOd520=";
+    };
     "input_3d.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_3d.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_3d.mp4";
       hash = "sha256-viLu+qMaGOcn3NX75+b39OeNGE6V9Ug6kRbTCQTqXfs=";
     };
+    "input_face-1.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_face-1.png";
+      hash = "sha256-LiiZOySgD2CzH/418ea/ls0RBfVzT6gc3JWnBK17Duo=";
+    };
     "input_reference_icon.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_reference_icon.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_reference_icon.png";
       hash = "sha256-C2EBZQ1NSSGUlRHfHQrIL0MkBUKaJ1aw2OOWa4YTnd4=";
     };
+    "input_storyboard_video.jpg" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_storyboard_video.jpg";
+      hash = "sha256-0SriGV5f80pgm4YUAEpM1DmJeuKNPPjHEvshFCcnUMs=";
+    };
     "input_style_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_style_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_style_1.png";
       hash = "sha256-mjGtgKUABzLrPOt3l3XZkaXyTrMe9A4OGkPaCSZPX6w=";
     };
     "input_style_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_style_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_style_2.png";
       hash = "sha256-2fBxKGJvMW+oiqkRqpWG+Mp7ntJBa6u8OgG/Ti9YRZs=";
     };
     "input_style_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_style_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_style_3.png";
       hash = "sha256-4fRqK4bsw0tBwE6ebdsB2IyJzRu56D+Ge4gIDJfCf/s=";
     };
     "input_style_4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_style_4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_style_4.png";
       hash = "sha256-yZcJGuojXermzaDla29a8iSQoKELuyK3xfHSsJXiA+8=";
     };
     "input_style_5.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_style_5.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_style_5.png";
       hash = "sha256-sOFQbhQzYarn1a3YW8vcpHyvATEAVRaE3Vuaq/bcyHs=";
     };
+    "input_templates_rob_realistic_2k_images_quick_variations.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_templates_rob_realistic_2k_images_quick_variations.png";
+      hash = "sha256-FvQlsWlSwDU6YJV6ehgYq/ueNycgiDXrxG+/vTezbzU=";
+    };
     "input_upscale.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/input_upscale.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/input_upscale.mp4";
       hash = "sha256-f4IB7DAXuhPOB96ca1Micaimze/Ltzi5qTf+PilIDH0=";
     };
     "ivory_rider.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ivory_rider.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ivory_rider.png";
       hash = "sha256-hAOuVECexIZEG3Y1nB1l15wAVpahwB0VOF7BkRKMgus=";
     };
     "ivory_rider_left_side_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ivory_rider_left_side_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ivory_rider_left_side_view.png";
       hash = "sha256-4RBNNUTdOkv0LWVdxgeEMl9DHPFtNgHVbehCm9QQD0w=";
     };
     "ivory_rider_right_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ivory_rider_right_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ivory_rider_right_front_view.png";
       hash = "sha256-ZfwrXWzcWtxaUFBTY5UUIut5Oy5amj9q8KZubMDD1t4=";
     };
     "ivory_rider_right_side_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ivory_rider_right_side_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ivory_rider_right_side_view.png";
       hash = "sha256-OjbAM4kq03kRJPZ91+veqs+/r+1M2za8LAhCBxya5Uk=";
     };
+    "japanese_street_alley.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/japanese_street_alley.png";
+      hash = "sha256-kyAnHKH63Q92nqXYX+JGSklorcczI4L51XkFZh0qnxY=";
+    };
     "joker_back.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/joker_back.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/joker_back.jpg";
       hash = "sha256-QM+74krViHf1o/QX4KhWbqSul/RzMKQ584ogyf8PEKA=";
     };
     "joker_front.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/joker_front.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/joker_front.jpg";
       hash = "sha256-4lROnavniMiDr1c5E1MrP2KVsw8vE+WJwvXuHh/HRP8=";
     };
     "joker_side.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/joker_side.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/joker_side.jpg";
       hash = "sha256-JkIIe2jTUv9wTIfHOhVMrv+sl7tFU0s4jcdR13Z1/eI=";
     };
     "joy_snap.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/joy_snap.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/joy_snap.png";
       hash = "sha256-5HleZYKLVEOGvCtn442I5EqOQx7MwwRuXmP0UQ59eC0=";
     };
     "kling_avatar_input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/kling_avatar_input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/kling_avatar_input.mp3";
       hash = "sha256-4LE19o6XObHESq7NJ61mgyEUigcCy+7YvUBbe3OJg7I=";
     };
     "kling_o3_video_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/kling_o3_video_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/kling_o3_video_input.mp4";
       hash = "sha256-1ARWXKSg98nN8virNxyIE3ddMMF+msVLrQckaQyR2PU=";
     };
     "lawyer.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/lawyer.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/lawyer.mp4";
       hash = "sha256-QWTqBYo9pP5qvAKvDwssuuPNSJC8rLTT8lnJe+QraXI=";
     };
     "leather_sofa.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/leather_sofa.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/leather_sofa.png";
       hash = "sha256-vkOH5zTxTFutPxMowXMdSsb4W5UXVmxN37HUSNltUcQ=";
     };
     "lighter.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/lighter.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/lighter.mp4";
       hash = "sha256-e3a0opvuD0YSSIncTP7kN0rM/Cmr19+VoD40Xp5ecEw=";
     };
     "lightning_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/lightning_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/lightning_man.png";
       hash = "sha256-py1qKvAiiByo+QzsGiNC0PqruEp29ZhkuOuPS6ex85Y=";
     };
     "little_bot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/little_bot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/little_bot.png";
       hash = "sha256-4U0u4QZiNdq0TjslSZJGqqs+Qq2hK2YQgHdgUta9bq0=";
     };
     "live_portrait_character.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/live_portrait_character.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/live_portrait_character.png";
       hash = "sha256-EY5Et0ifmZmPbykJyELLUEDMnokYk8ub1O5oo1HBscU=";
     };
     "live_portrait_expression.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/live_portrait_expression.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/live_portrait_expression.mp4";
       hash = "sha256-kSoC3P/vmxptZkHJpI4XBJAIDDcV3J9V2R4WhIPSfm4=";
     };
     "lizard_rapper_in_bar.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/lizard_rapper_in_bar.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/lizard_rapper_in_bar.png";
       hash = "sha256-zV0DPdbA9wbOMZDul+bjkl1tSRBae7yLjqa4aaQKHu8=";
     };
     "logotype_texture.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/logotype_texture.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/logotype_texture.png";
       hash = "sha256-OVjMegnmh4oDSbqjk6hT7M4SXU4I1yBUGwB/Fdxv8T4=";
     };
+    "looped_restyler_init.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/looped_restyler_init.png";
+      hash = "sha256-GFCtzbGKDoD2NcKgrZA2T/X056IbcwTWvyPT2YArZg0=";
+    };
     "low_angle_shot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/low_angle_shot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/low_angle_shot.png";
       hash = "sha256-io5ogiitBYRXToiR5JGB4aLbZuevKnRSWyDGEas2XdA=";
     };
+    "low_view_classic_car.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/low_view_classic_car.png";
+      hash = "sha256-8Jw51oDBQOHvjfdiEYHRUoZ2DeWREIx/QsAebvpmUGE=";
+    };
     "ltx2-a2v-input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ltx2-a2v-input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ltx2-a2v-input.mp3";
       hash = "sha256-Oc/qMB+x5vmANlVfJ64PR9nuA6UGvBgqIyrJCxgvpIA=";
     };
     "ltx2-a2v-input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ltx2-a2v-input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ltx2-a2v-input.png";
       hash = "sha256-M4IGxnA9UfVBnTScDzHYJuiKsPtO6SD7qFyWdpkfIqY=";
     };
+    "ltx_23_audio.mp3" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ltx_23_audio.mp3";
+      hash = "sha256-Sg2P/QQhQ/zcsN5m4ue33QuxYaot/oLRqjEao95wjIs=";
+    };
     "ltx_2_canny_1st_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ltx_2_canny_1st_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ltx_2_canny_1st_frame.png";
       hash = "sha256-sGbXt3QJk8dpi5SRJmc1aKYsnDNXBhxHOxPThU1W260=";
     };
     "ltxv_image_to_video_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/ltxv_image_to_video_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/ltxv_image_to_video_input_image.jpg";
       hash = "sha256-eQ9Dkm4Bz4Hc6q8JHp6M9eP8fASf+7IGjDRvDOTgM2g=";
     };
+    "lucky_cat_sculpture_front.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/lucky_cat_sculpture_front.png";
+      hash = "sha256-rid6QcQ3W0FxVh/p0YfRhRF+f4dNtEX6sDgYxpwhlcE=";
+    };
     "magical-portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/magical-portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/magical-portrait.png";
       hash = "sha256-uUtszH35G/6a5+kMP6D0wX7VO6pbDByS/iwtRPtNdMg=";
     };
     "magnific_style_reference.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/magnific_style_reference.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/magnific_style_reference.png";
       hash = "sha256-IydN70w5lkiTxwRaPOISggSPsMBYtUCPLjKOhwjnF6w=";
     };
     "man_in_daydream.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/man_in_daydream.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_in_daydream.png";
       hash = "sha256-kAqvoEDs49Z8kv0jWeBT+4iGv0h3epImeH6xrJi005A=";
     };
+    "man_in_street.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_in_street.png";
+      hash = "sha256-1wgWh8bJ4XNEjUWctJnC+yCABZsf1mVrsN4tVx7XJqw=";
+    };
     "man_in_the_rain.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/man_in_the_rain.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_in_the_rain.mp4";
       hash = "sha256-gqRbF3IbNbT8CaBNVq9pC3/Pwk6KAGcmIVh9Ra3w4+I=";
     };
     "man_on_desert.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/man_on_desert.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_on_desert.png";
       hash = "sha256-whBp9CsHkjTchwo39/JqayRFySWQiQ3FIDGVBnlwx4w=";
     };
     "man_with_dog.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/man_with_dog.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_with_dog.png";
       hash = "sha256-hcbPy/0oOuDuHWQPyMlQmjoC4B6TO4OfG/y82c/erLc=";
     };
     "man_with_old_computers.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/man_with_old_computers.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_with_old_computers.png";
       hash = "sha256-c+z43v1g+2fSpjoENWPaM6/SKuc1OpGi7mqsb3PJFcg=";
     };
     "man_with_rose.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/man_with_rose.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/man_with_rose.png";
       hash = "sha256-6kbDdp1d7gp//Df4H8wTSQlCDwjWpwV6jIrdpDnnoTg=";
     };
     "midnight_coasta.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/midnight_coasta.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/midnight_coasta.png";
       hash = "sha256-Hvwdc5pptG36UT5dFHzMk70+Ke2Bq4XYvR2X5MJFLx8=";
     };
     "minimalist_sky_view_lounge.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/minimalist_sky_view_lounge.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/minimalist_sky_view_lounge.mp4";
       hash = "sha256-iIUmj68r4Fiel8IDf6PnuGnu1qF7SiA8gRn/DfJKTTk=";
     };
     "minimalist_sky_view_lounge.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/minimalist_sky_view_lounge.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/minimalist_sky_view_lounge.png";
       hash = "sha256-oahzVt/+6WJSN7ckQhi09WZBSnDgQ/CU8YfwTTR8WlI=";
     };
     "minimalist_wooden_sofa_living_room.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/minimalist_wooden_sofa_living_room.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/minimalist_wooden_sofa_living_room.png";
       hash = "sha256-z9AAx6PWD/K5BnCf+oTlF0CPRunLMF/hpdq0p5BfTpk=";
     };
     "mixing_controlnets_pose_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/mixing_controlnets_pose_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/mixing_controlnets_pose_input.png";
       hash = "sha256-bf8jZZtQ825j0kK9yoQBFlkMgpJivtHVqBmWJ5AHCRI=";
     };
     "mixing_controlnets_scribble_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/mixing_controlnets_scribble_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/mixing_controlnets_scribble_input.png";
       hash = "sha256-ZNohZPw0CuwdVNR5o/tMiTmG78x3RSv04IO2xFEBHiE=";
     };
     "moonlit_cliff_house.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/moonlit_cliff_house.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/moonlit_cliff_house.png";
       hash = "sha256-sqYb8Ee6Wr7+R2BR4ckpOi4mA3SxG3GZBGtQMlU8VqI=";
     };
+    "motor_cycle.fbx" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/motor_cycle.fbx";
+      hash = "sha256-bX8R78qT2y7OdWz/VEKObddhdpvu/g9hL1AiqQqk64M=";
+    };
+    "nb2-single_image_sprite_sheet-input" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/nb2-single_image_sprite_sheet-input";
+      hash = "sha256-rQT2tfbpXL5nmvZKal/DRCAFqH8vIzFwSord6P4nfAE=";
+    };
     "noisy_background.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/noisy_background.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/noisy_background.mp3";
       hash = "sha256-CrfiCTRQpNVZ1vuQKT+FDZTsmodUYEb0Z9eB/n3P7J8=";
     };
     "normals_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/normals_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/normals_input.mp4";
       hash = "sha256-VKxbNsuQe05lxT5vCdlI3TxOUUpenBTaOmZkTFbj8ZQ=";
     };
     "nun_in_church-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/nun_in_church-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/nun_in_church-1.png";
       hash = "sha256-wnS17j1iMLBJwbienwWbEdFmPyw1lS6h59TJwIFwr34=";
     };
     "nun_in_church-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/nun_in_church-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/nun_in_church-2.png";
       hash = "sha256-4CXRlHM984zT4SAsMPFAsWtBUSeAHeeyQXpK+BBNErk=";
     };
+    "old_man_dancing.jpg" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/old_man_dancing.jpg";
+      hash = "sha256-gHDPQ9QJ4QXq2nW4S5KzzKvOOtGbQ5XhfBh64sH+q30=";
+    };
     "orange_beauty_trio.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/orange_beauty_trio.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/orange_beauty_trio.png";
       hash = "sha256-3qN/30fP612Wo6iCfswDX/ELmdgCDTiQl4wEVptpiks=";
     };
     "outfit-streetwear.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/outfit-streetwear.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/outfit-streetwear.png";
       hash = "sha256-e1wHTlsOmPCiXeUFFXCc0leuFhnl4Zm0KBhuLfmZwQk=";
     };
+    "outfit-templates_rob_fashion_shoot_vton-4in1.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/outfit-templates_rob_fashion_shoot_vton-4in1.png";
+      hash = "sha256-O8aqtGqB8WeLygj56tqaqu29ce5qu1jrulT22OnUfCs=";
+    };
     "outfit.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/outfit.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/outfit.png";
       hash = "sha256-ItLaeBPxcvEIhNNGligUvoU5kn6TkFns+h7wX/TACSY=";
     };
     "outfit_image-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/outfit_image-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/outfit_image-2.png";
       hash = "sha256-DMDyZgLdFn4RszFbi76hEvuim/ZR+FufwLx3opK7nlA=";
     };
     "pink_robot_back.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/pink_robot_back.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/pink_robot_back.png";
       hash = "sha256-Gwn3cQFrbZtUSo4tAsOuNpZzi25L0huNDvE39xwgfzs=";
     };
     "pink_robot_front.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/pink_robot_front.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/pink_robot_front.png";
       hash = "sha256-H7U44kMYPq8f5bak2CK/RP72+4Doxebj5dompDhdCWU=";
     };
     "pink_tone_chair.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/pink_tone_chair.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/pink_tone_chair.png";
       hash = "sha256-Y1YwPbNE2JRyP24+drRYopv0QHRSLbR03XYoJfXgu0s=";
     };
     "pirates_dancing.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/pirates_dancing.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/pirates_dancing.png";
       hash = "sha256-CYPRHfzLkH1oJEjwA2lLf5dgjileCNUArLFbzqFjohI=";
     };
+    "playful_portrait.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/playful_portrait.png";
+      hash = "sha256-yiC8thZ+qzBv8sIC24TSd7Fli2NLQ+cTDOMIqdh8m88=";
+    };
     "pose_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/pose_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/pose_input.mp4";
       hash = "sha256-gxRpeVnByFs9QxLCim7mIbReK9YAXpxEKtJNgo8QvRU=";
     };
     "pray.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/pray.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/pray.png";
       hash = "sha256-lnGowwAyvlPwzBAoYmEuEtZR59knln81zSEq3zhkmI8=";
     };
     "prince_and_phoenix.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/prince_and_phoenix.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/prince_and_phoenix.mp4";
       hash = "sha256-1ARWXKSg98nN8virNxyIE3ddMMF+msVLrQckaQyR2PU=";
     };
     "product-cleanser.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/product-cleanser.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/product-cleanser.jpeg";
       hash = "sha256-sLl0CZEewHbvL203wUrnFs3sHDgD+Mm8GC+oC4Xnz28=";
     };
     "product-toothbrush.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/product-toothbrush.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/product-toothbrush.png";
       hash = "sha256-KKxSgfsv/el6UeQPK0dUDV/qdcgKkqB/s9+CyF3as8o=";
     };
     "product_car.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/product_car.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/product_car.jpg";
       hash = "sha256-X4b9knKKBYqxEbwS/rJI+ykl39mQOHr7SpBQItaw8A4=";
     };
     "product_shoe.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/product_shoe.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/product_shoe.jpeg";
       hash = "sha256-CTMUkZqXGj5B4Byq7ogIPdOpMV53jG+ti8THHdwG9Yg=";
     };
+    "projection_light_portrait.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/projection_light_portrait.png";
+      hash = "sha256-NHoe7IelbLtDOB7HiHL9fcJaJXpykcmpgNIl3p459rg=";
+    };
     "puppy_with_blue_bandana.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/puppy_with_blue_bandana.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/puppy_with_blue_bandana.png";
       hash = "sha256-V8gWYimH0vn1lAazlTbTZZ99LgJkmoHcSREunWDJJqM=";
     };
     "quokka_bath.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/quokka_bath.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/quokka_bath.jpg";
       hash = "sha256-pY+wZAAoku7+LIYYNyLVXKXLP81URX6/AdAg9apS/Eo=";
     };
     "quokka_relax.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/quokka_relax.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/quokka_relax.jpg";
       hash = "sha256-2UJwlQ1LXg2LJitTptxVu55zOYW+bjNnA2Krt3rbmqI=";
     };
     "raccoon_rocker.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/raccoon_rocker.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/raccoon_rocker.png";
       hash = "sha256-HqH8helNabUl/ez1fdJ8rVy7qYiDNJh/Vb97scl4w3M=";
     };
+    "rapper_on_cliff_with_moon.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/rapper_on_cliff_with_moon.png";
+      hash = "sha256-pO1v17BwORJvZUayMLq4/+JOgVKbokA0LqNMGjE7wkw=";
+    };
     "recraft_style_ref-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/recraft_style_ref-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/recraft_style_ref-1.png";
       hash = "sha256-wskUiRTUwi5s5oKmiB37feRMpgzNBrLwtDhoXcb/aTQ=";
     };
     "recraft_style_ref-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/recraft_style_ref-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/recraft_style_ref-2.png";
       hash = "sha256-GJ4zJh6dLASpe51att2EEZ3rAh/KqSJCiPEMFmL5Hhk=";
     };
     "recraft_style_ref-3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/recraft_style_ref-3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/recraft_style_ref-3.png";
       hash = "sha256-vCHUQ6kK60cI0DbZfsydVslRlZg8VgrI9XSZICc0JT4=";
     };
     "recraft_style_ref-4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/recraft_style_ref-4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/recraft_style_ref-4.png";
       hash = "sha256-x9WroH4KCgKbXGfmoT0R+WhbMJmJUZ0RdIdBHzGfahc=";
     };
     "red_car.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/red_car.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/red_car.png";
       hash = "sha256-u87/LYi3ybMxS6IRHI55SwH2WiqiwoEDAUaqX45BqRg=";
     };
     "red_haired_girl.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/red_haired_girl.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/red_haired_girl.jpg";
       hash = "sha256-Ld949sGP6V+SHdx8z4z2/9MxbSf+ji0vK9bfxHcMy9w=";
     };
     "reference_ad.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/reference_ad.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/reference_ad.png";
       hash = "sha256-GK6bTlUEpXtHgmW9r3fyQUMFvQrJqmgj6iT4MdF8liQ=";
     };
     "robed_women.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/robed_women.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/robed_women.png";
       hash = "sha256-5ey7Aw15ndjzC0GWwre2AcSvt1B6m49EKz3H0Y2fFOk=";
     };
     "robot-warrior.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/robot-warrior.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/robot-warrior.png";
       hash = "sha256-O5Fpe3R8LQ6igrjZLROJGsi8ME+x28cIqydZungdmoQ=";
     };
     "robot_office_worker_in_space.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/robot_office_worker_in_space.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/robot_office_worker_in_space.png";
       hash = "sha256-BdwhI2qjy20WGPDcsz40ulKcg58ieo/RYfDwMpdgpOo=";
     };
     "roller_coaster.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/roller_coaster.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/roller_coaster.mp4";
       hash = "sha256-7aeEhp5G02yWu4zuoN38eVJntl+ANwIDAnuVNHvTurs=";
     };
+    "safari_outfit.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/safari_outfit.png";
+      hash = "sha256-HkpHkuQpX9gMor91B0Oxti59+FImRNNI5RJs7PDJBNQ=";
+    };
     "sci-fi_mech.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sci-fi_mech.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sci-fi_mech.png";
       hash = "sha256-1bHd95QVlTdOnTXTtGO/pWuYVZsQO1RnBP6HEUhezNY=";
     };
     "sd3.5_large_blur_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sd3.5_large_blur_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sd3.5_large_blur_input_image.png";
       hash = "sha256-LgiE0IjXv3k16Du6lnYRrYEqgqG2nf8bvm5mAoGpwdw=";
     };
     "sd3.5_large_canny_controlnet_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sd3.5_large_canny_controlnet_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sd3.5_large_canny_controlnet_example_input_image.png";
       hash = "sha256-lLQ9UUmIF4NKXRLalSY0Y8lSN8NqLyM3Bf0FRlwJHAY=";
     };
     "sd3.5_large_depth_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sd3.5_large_depth_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sd3.5_large_depth_input_image.png";
       hash = "sha256-DcQmisZx1CungoxQ2m5zDnim1/eNSqZBQp11BZUpSfk=";
     };
     "sdxl_revision_text_prompts_ref_image1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sdxl_revision_text_prompts_ref_image1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sdxl_revision_text_prompts_ref_image1.png";
       hash = "sha256-vsexTh5veCMK3cZEhSfT9T7oX8mGd82cYpMtE5yx1K4=";
     };
     "sdxl_revision_text_prompts_ref_image2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sdxl_revision_text_prompts_ref_image2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sdxl_revision_text_prompts_ref_image2.png";
       hash = "sha256-5OzySXpJaETiYtc4pU+dW1FdgMg8PTRniooag84MdUs=";
     };
+    "seamless_loop_input.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/seamless_loop_input.mp4";
+      hash = "sha256-QN6EEzuawIEtRCaSFfC/pgTv0Js29cITn/qOLU5a1Fo=";
+    };
+    "shane_video_restyle_ref_frame.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/shane_video_restyle_ref_frame.png";
+      hash = "sha256-t2D/p7dlMJ8AujCqMGsSVuUY/t0NPr3CpCD+JLF8drE=";
+    };
     "sheep_knit.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sheep_knit.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sheep_knit.jpg";
       hash = "sha256-VUj/0lV+WE4fpU8isunNgAOPBbwAJAs3vZZcYmCl4ng=";
     };
     "silent_sanctuary.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/silent_sanctuary.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/silent_sanctuary.jpg";
       hash = "sha256-rnCEhMPGYlLfG0Z1Q8oWrzAaz3PjVPltpUhP20bl6Jk=";
     };
     "snake_on_jacket.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/snake_on_jacket.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/snake_on_jacket.jpg";
       hash = "sha256-4D8HhhrAgnyXVjMteNEfkJnRzOE4xxJ8fakcLPElMW0=";
     };
     "snow_bike_jump_crew.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/snow_bike_jump_crew.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/snow_bike_jump_crew.png";
       hash = "sha256-BtvIMqR9nndmzswvu6/N9tWz8rjTC7QEBr5l5P82dyM=";
     };
     "snowboard_rush.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/snowboard_rush.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/snowboard_rush.png";
       hash = "sha256-xqP8Cvut8h4SG9Jv7Y6ipTW8E5IP6WmbrEf1FLnW5eA=";
     };
     "spear_warrior.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/spear_warrior.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/spear_warrior.mp4";
       hash = "sha256-nP2vx0UlzY64/Pb0yUBLJ1KWaTBkyrWCgQ2focIfw3k=";
     };
     "sportbike_rider.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sportbike_rider.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sportbike_rider.png";
       hash = "sha256-fvjkwyBhOJw5HBySbTbmE4lf9x8XDST1NQNfalNZQfg=";
     };
     "squirrel_in_flower_garden.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/squirrel_in_flower_garden.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/squirrel_in_flower_garden.mp4";
       hash = "sha256-cRsWjljWtOUf94ca9+1skxPAWn9bAwSt+XYMkwOMj68=";
     };
     "street_dancer.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/street_dancer.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/street_dancer.mp4";
       hash = "sha256-/g22opGKO37x2XBGZNTyMmif/RMQyKriwh4mEyDD5M4=";
     };
     "streetwear_fox.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/streetwear_fox.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/streetwear_fox.jpg";
       hash = "sha256-FAlhPd9wYZNcWNGPSdqGYI0UpoSbL1vbLLKJVH/daRE=";
     };
     "subject-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/subject-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject-1.png";
       hash = "sha256-uzUUyDzapzCgROeUSISqWIZZQROlOwDI2d3rnysh6BU=";
     };
     "subject-elderly-lady-portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/subject-elderly-lady-portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject-elderly-lady-portrait.png";
       hash = "sha256-LYyGLdIEdM88YQyXUTAioq6MwpmegXrWu7SQf0S51o0=";
     };
     "subject-girl-holding-skincare-bottle.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/subject-girl-holding-skincare-bottle.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject-girl-holding-skincare-bottle.png";
       hash = "sha256-RgNqPi/c1s8uTLlszV7CmqKovxTVKIEJ9tUBZdAvmcI=";
     };
     "subject-profile.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/subject-profile.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject-profile.png";
       hash = "sha256-oPzknvwy87EVzKH1m9Y6K+byH7cGTjVrbvKugry3/NI=";
     };
+    "subject-templates_rob_fashion_shoot_vton-4in1.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject-templates_rob_fashion_shoot_vton-4in1.png";
+      hash = "sha256-W6qiKc861HvaKMmJS/hvQgXlU5nkC1ELHjcX3ec9wk8=";
+    };
     "subject.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/subject.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject.png";
       hash = "sha256-UC4bd3RaUoJuOs7VHeyWl2a7PtM937UieKVdkff/X3c=";
     };
+    "subject_close.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject_close.png";
+      hash = "sha256-gAXqtFn/8YyuM1u7y1mDrdUkrjynJkE5MEMAxM971pQ=";
+    };
+    "subject_far.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject_far.png";
+      hash = "sha256-Q94ywyiCWm9Mpnz1x44p/XS5CdWPEMBCl/kk5aqrO08=";
+    };
     "subject_leopard_hair_croc_jacket.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/subject_leopard_hair_croc_jacket.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/subject_leopard_hair_croc_jacket.png";
       hash = "sha256-2s+JA4ZIFULEssTe94w+Z6yZtO/d1YHxQ+j90H1RzaI=";
     };
     "sunlit_girl_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sunlit_girl_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sunlit_girl_portrait.png";
       hash = "sha256-7h9oEoOuy83ixg6yuuctFknKBgMP5WaHrklyYigWNVA=";
     };
     "sunlit_rooftop_capture.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/sunlit_rooftop_capture.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/sunlit_rooftop_capture.png";
       hash = "sha256-OISFIRKuWYP9kWRSwl5UNOEXnFX4hv3LLkX26ZD+CWo=";
     };
     "template-3x3_Grid_For_Product_Ads Assets.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/template-3x3_Grid_For_Product_Ads%20Assets.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/template-3x3_Grid_For_Product_Ads%20Assets.png";
       hash = "sha256-N6WzNJr4vwtJAbP+sEkmdy6N+RIcHCvlUYURettPHtY=";
     };
     "template-Magazine_Cover_&_Packag_Design.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/template-Magazine_Cover_%26_Packag_Design.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/template-Magazine_Cover_%26_Packag_Design.png";
       hash = "sha256-LZSHf9u8g1wxmJUkVHKmq4pkGO+siPUwx6bSvAvb64o=";
     };
     "template_Poster_Scene_Mockups.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/template_Poster_Scene_Mockups.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/template_Poster_Scene_Mockups.jpg";
       hash = "sha256-0HF8NFPt4IEfftjQJ49CBEzKq8GOPpiKkFn0mSV+tdU=";
     };
+    "template_eric_exploded_view_first_frame.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/template_eric_exploded_view_first_frame.png";
+      hash = "sha256-YpO8Y7ryTTzCq0NenuR4wdEbTURMn4AIOlakFTyAiTI=";
+    };
+    "template_eric_exploded_view_last_frame.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/template_eric_exploded_view_last_frame.png";
+      hash = "sha256-cdoF+7u75dpsRmCVhkIYYxeeNBu+di9hh0RutgYd+kE=";
+    };
     "templates-character_sheet_pink_silver_outfit.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/templates-character_sheet_pink_silver_outfit.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/templates-character_sheet_pink_silver_outfit.jpg";
       hash = "sha256-3TwGj+Pr3Y6TYsc0p93q+yW7eH3d752ULN13l2+4xaM=";
     };
     "templates-sprite_sheet_input-sprite-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/templates-sprite_sheet_input-sprite-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/templates-sprite_sheet_input-sprite-1.png";
       hash = "sha256-vfs+g8j6vA7OJcjktznX85uljneWJnJojfLtPt1O+c4=";
     };
+    "templates_rob_image_to_real-input.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/templates_rob_image_to_real-input.png";
+      hash = "sha256-db/XcaexnDQyL4szFP6OHyYbHxdQqHd6xVFrKbENp04=";
+    };
     "texture_fur.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/texture_fur.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/texture_fur.png";
       hash = "sha256-boN/Z4DxseVnTqsk+CisKSDifrj5966DWDt30FfX3Hg=";
     };
+    "toy.glb" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/toy.glb";
+      hash = "sha256-ukASxy6n4Ccx095IIY1NsRiYcUIyYzd5CCtSTyGh0b0=";
+    };
     "two_character_talking.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/two_character_talking.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/two_character_talking.png";
       hash = "sha256-iKnXvTgyMEpbZmJsRCiG8Lgt284XYInlBLiur0zDMz4=";
     };
     "two_characters.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/two_characters.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/two_characters.png";
       hash = "sha256-bPEnut+SRKQKyv7MsNilZihkDAGmzv55pjLPgHcdRAg=";
     };
     "utility-audioseparation-audio-input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/utility-audioseparation-audio-input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/utility-audioseparation-audio-input.mp3";
       hash = "sha256-lKvD15M5HEbs14loiPlYVSMXjW8lWSLIsZU6ZXNgS00=";
     };
     "utility-lineart-video-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/utility-lineart-video-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/utility-lineart-video-input.mp4";
       hash = "sha256-Z5UTG5EIuJotD4Fdj1DjqPBeMF1cQjVieKCl1saBoL0=";
     };
     "video_humo_input_audio.wav" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_humo_input_audio.wav";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_humo_input_audio.wav";
       hash = "sha256-TpIIktPTPruKBNdylgoCfxhfpVITzgxgz9DsP68ZHo8=";
     };
     "video_humo_reference_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_humo_reference_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_humo_reference_image.png";
       hash = "sha256-OmZi66CcELctdjy5R8o45xeZi6/FXX0MFPcqFBDuHrA=";
     };
     "video_hunyuan_video_1.5_720p_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_hunyuan_video_1.5_720p_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_hunyuan_video_1.5_720p_i2v_input_image.png";
       hash = "sha256-8lAqnITcI3m920RM/ZXgBX8J0zAO6z8RzpNkdIxmW14=";
     };
     "video_wan2.1_fun_camera_v1.1_1.3B_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2.1_fun_camera_v1.1_1.3B_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2.1_fun_camera_v1.1_1.3B_start_image.jpg";
       hash = "sha256-/PYZEO01bQ9s4FIanmZJ/qIhBYdOBT2EfW33q59uptU=";
     };
     "video_wan2.1_fun_camera_v1.1_14B_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2.1_fun_camera_v1.1_14B_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2.1_fun_camera_v1.1_14B_start_image.jpg";
       hash = "sha256-5CsKCe2E2Qwn6Wwp7nVZCK48vdsuLgFVMWzNQ44wt8o=";
     };
     "video_wan2_2_14B_animate_original_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_animate_original_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_animate_original_video.mp4";
       hash = "sha256-YA2ShjHZEmYdwPwWStDBR2wVqsBamjU6XKfdlmy5Nzg=";
     };
     "video_wan2_2_14B_animate_reference_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_animate_reference_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_animate_reference_image.png";
       hash = "sha256-mkYSY6vUJ55xv/YxpQvcoYCezxUFZGYo386nPyVI7Rg=";
     };
     "video_wan2_2_14B_flf2v_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_flf2v_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_flf2v_end_image.png";
       hash = "sha256-nMzPhtUBvwIroo1EnJxBujg87wQWSlBKyFwJc/NBzO0=";
     };
     "video_wan2_2_14B_flf2v_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_flf2v_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_flf2v_start_image.png";
       hash = "sha256-9Qpjq2q1QGw5Pdfyl/l5O6OcHwiLxnm3vRikMdjk73g=";
     };
     "video_wan2_2_14B_fun_camera_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_fun_camera_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_fun_camera_start_image.jpg";
       hash = "sha256-IdA73u+9qfD1Jdg8lF3AgjJrGeBtI5Wh0ajLiTaCRx8=";
     };
     "video_wan2_2_14B_fun_control_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_fun_control_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_fun_control_start_image.jpg";
       hash = "sha256-f078fvVKMomsFBs9PY+pOpNK4UgAdWKuds/mkSU+j4E=";
     };
     "video_wan2_2_14B_fun_control_start_image_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_fun_control_start_image_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_fun_control_start_image_control_video.mp4";
       hash = "sha256-8Xs8yRKH1miZgbYkvnZDu5dcXzUEUuEbPmSab/0ySVQ=";
     };
     "video_wan2_2_14B_fun_inpaint_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_fun_inpaint_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_fun_inpaint_end_image.png";
       hash = "sha256-ZOhYTL4am5VKAlmdqZ2+dAymjYQMRgisanG9oAPfO2M=";
     };
     "video_wan2_2_14B_fun_inpaint_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_fun_inpaint_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_fun_inpaint_start_image.png";
       hash = "sha256-Sip4aVFcP4iHcH+lZ2Api9RRSVYOkGDR72CC/WafUu8=";
     };
     "video_wan2_2_14B_i2v_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_i2v_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_i2v_input_image.jpg";
       hash = "sha256-u32aN9qx9Qj3I1jlc8YSEpYuM3xE1RHDKF22cMUp4O8=";
     };
     "video_wan2_2_14B_s2v_input_audio.MP3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_s2v_input_audio.MP3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_s2v_input_audio.MP3";
       hash = "sha256-BrU8d36/JDPEIpBEHoe+2uoXp9zuG2r+47YsjpZ76ls=";
     };
     "video_wan2_2_14B_s2v_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_14B_s2v_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_14B_s2v_reference_image.jpg";
       hash = "sha256-zKFDzkYQtckeo0ZbEQAe8/AxZ0HggUHulCy8211daYE=";
     };
     "video_wan2_2_5B_fun_control_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_5B_fun_control_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_5B_fun_control_control_video.mp4";
       hash = "sha256-/aWvd7LQGOuPMK69OkH/woGICvCUYE0ZpcBAbVX2k5I=";
     };
     "video_wan2_2_5B_fun_control_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_5B_fun_control_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_5B_fun_control_start_image.png";
       hash = "sha256-4ZrPfVPkV6g8k1PACgMIMLK+88MRMZjSI16wwoyipDA=";
     };
     "video_wan2_2_5B_fun_inpaint_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_5B_fun_inpaint_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_5B_fun_inpaint_end_image.png";
       hash = "sha256-hGttylHtW/X+f2tdp6bFdB/KpU5bA9y8WOUXYVQejHM=";
     };
     "video_wan2_2_5B_fun_inpaint_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan2_2_5B_fun_inpaint_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan2_2_5B_fun_inpaint_start_image.png";
       hash = "sha256-J5LnNl5r2kck8wEojx2oWO68kVxu7dUVF3oWhKt2l1Q=";
     };
     "video_wan_ati_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_ati_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_ati_input_image.jpg";
       hash = "sha256-bXOXVVfWxjnuXgVUOGH9DGLoBNx0xvzBLwA6+AKEwLE=";
     };
     "video_wan_vace_14B_ref2v_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_14B_ref2v_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_14B_ref2v_reference_image.jpg";
       hash = "sha256-TSjYsviHjq7oLGS59nWrMcCyIWE4hA1cPMJ94C5okGQ=";
     };
     "video_wan_vace_14B_v2v_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_14B_v2v_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_14B_v2v_reference_image.jpg";
       hash = "sha256-B8Ok+zQBDojkRv+oWFQ7yl0rnNn5k/ppxYiSDha9OIE=";
     };
     "video_wan_vace_14B_v2v_reference_image_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_14B_v2v_reference_image_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_14B_v2v_reference_image_control_video.mp4";
       hash = "sha256-/00FNekObM3z0MBOjPjuHZZ+k7VTysgw4xAwiQwPaR4=";
     };
     "video_wan_vace_flf2v_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_flf2v_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_flf2v_end_image.png";
       hash = "sha256-Oiaai0GT4KH+SBSjpKnMuZ2HnK+8Kr2pXOR6xlvG+iQ=";
     };
     "video_wan_vace_flf2v_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_flf2v_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_flf2v_start_image.png";
       hash = "sha256-VdcFhHesdmGXU8f6rn/phnN80Magr887NRUj7TCnScU=";
     };
     "video_wan_vace_inpainting_1st_frame_and_mask.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_inpainting_1st_frame_and_mask.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_inpainting_1st_frame_and_mask.png";
       hash = "sha256-eaMCTb+vk8nfq56QZdszu6u5yNbwV5dSR8Ef8pjaWRs=";
     };
     "video_wan_vace_inpainting_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_inpainting_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_inpainting_input_video.mp4";
       hash = "sha256-L2ir7bFciZr48opobg8v1FouBx/N9z1vO6hwLT9NEHY=";
     };
     "video_wan_vace_inpainting_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_inpainting_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_inpainting_reference_image.jpg";
       hash = "sha256-B+B07v14EWIhSpo1zfsYtY2ZdFlPbHV6Ic8CQBLzqF4=";
     };
     "video_wan_vace_outpainting_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/video_wan_vace_outpainting_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/video_wan_vace_outpainting_input_video.mp4";
       hash = "sha256-DSMg0cweB1MJLADKvlTYTOhXCRVeJWwQPeEwDTUN/Q8=";
     };
     "view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/view.png";
       hash = "sha256-PeH3lHAuPP/mYh9ufoGV4c173VD3HFzeLBqvNcd1pK4=";
     };
     "vintage-girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/vintage-girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/vintage-girl.png";
       hash = "sha256-qpOUHd8NyWN6m1JukozY/GB4OE8bRo7cW4zo/JLnluw=";
     };
     "vintage_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/vintage_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/vintage_portrait.png";
       hash = "sha256-fbdLrJzzVQxjhh8mGWwNVeoF9/ZL5bV0Y1qnDdtL+mA=";
     };
     "vintage_robot.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/vintage_robot.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/vintage_robot.jpg";
       hash = "sha256-J7GrDmrD1DPKckCONie1hDi50S5txW5cTyWeUaiqH18=";
     };
     "voice_demo.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/voice_demo.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/voice_demo.mp3";
       hash = "sha256-jPmdU9yDTYoRIn+EgfxcqARGJbxu22peTWRg5fpZ660=";
     };
     "vr_ad.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/vr_ad.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/vr_ad.png";
       hash = "sha256-bCRu0Pe6oazVS2XZyd6UHXfY5AvzsZvfEYntCoe/kns=";
     };
     "wan2.1_flf2v_720_f16_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2.1_flf2v_720_f16_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2.1_flf2v_720_f16_end_image.png";
       hash = "sha256-np9tFQ8tJmsykY79ojYe+0RcwZuLLTaEt3YDeZAFQ+0=";
     };
     "wan2.1_flf2v_720_f16_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2.1_flf2v_720_f16_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2.1_flf2v_720_f16_start_image.png";
       hash = "sha256-dVIU+MkteUFfrHdKbZc/mXon6xaaJ/pSxTvEciUwbaY=";
     };
     "wan2.1_fun_control_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2.1_fun_control_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2.1_fun_control_control_video.mp4";
       hash = "sha256-PyqGyxQWqBC6PMFGIp8ZFNDr165p9iAVZCqy0uEH4AM=";
     };
     "wan2.1_fun_control_start_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2.1_fun_control_start_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2.1_fun_control_start_frame.png";
       hash = "sha256-DiHMqxIiNQ6WwyUNc+nDyApiGoaVCiNm/5h3VdhpBW4=";
     };
     "wan2.1_fun_inp_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2.1_fun_inp_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2.1_fun_inp_end_image.png";
       hash = "sha256-TdiVih+atrSmFlYvRcQO9r5aws51Oq38a40tPRzSrUo=";
     };
     "wan2.1_fun_inp_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2.1_fun_inp_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2.1_fun_inp_start_image.png";
       hash = "sha256-rIhYvO4yn5eZc7D5gFlbTj8j2j5q2WQt7furNjzdUaE=";
     };
     "wan21_scail-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan21_scail-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan21_scail-input.mp4";
       hash = "sha256-NsZAmnOJyWxXCdFJBJNlKQ8nSzGIkJ2R4Hjxq1D6aTY=";
     };
+    "wan22-animate-auto-character_replace-input.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan22-animate-auto-character_replace-input.mp4";
+      hash = "sha256-t5NaboIZrBKDHLnWe9jiXeeDrd4TfhGcGTXcxEJxDs8=";
+    };
     "wan2_1_infinitetalk_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2_1_infinitetalk_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2_1_infinitetalk_audio.mp3";
       hash = "sha256-qKEDU7wBEITyoNfgKz7ToWWH2JOHW8lfo1V7QKXPK/w=";
     };
     "wan2_1_infinitetalk_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wan2_1_infinitetalk_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wan2_1_infinitetalk_first_frame.png";
       hash = "sha256-mHXhLMtcGyTNIN1dkwbYqxWUd0CCC/Lo4PIzZR2ntYU=";
     };
     "warm_living_room.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/warm_living_room.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/warm_living_room.png";
       hash = "sha256-hRH0eSSoKbLOS7I9plinr9IjEuGMFc68jzh4wkvMIOU=";
     };
+    "white_tiger.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/white_tiger.png";
+      hash = "sha256-3U/5wEgWGHszmXULzS0v0PlAAJtzGVtFlKKV7kxw4fU=";
+    };
     "wind_woman.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wind_woman.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wind_woman.png";
       hash = "sha256-wh4HSFL49bIWXw0EqJlvER2LQpMd/rBYmf2ngjxkk/s=";
     };
     "woman_behind_veil.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/woman_behind_veil.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_behind_veil.png";
       hash = "sha256-Ebq7caXyPOQ/Uz/+2qOUC6tXZYXkTV1zJC8D48eCX5o=";
     };
+    "woman_holding_the_pipeapple.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_holding_the_pipeapple.mp4";
+      hash = "sha256-Rg5oOgGg6tJoX/pM4365C+bkjzDthY1mw78NV/Cjhwc=";
+    };
     "woman_in_red.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/woman_in_red.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_in_red.png";
       hash = "sha256-2LRwXUpaPjBEPZenpr22QZmSXha5CH8yrBV1QILkapQ=";
     };
+    "woman_runing_in_feild.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_runing_in_feild.png";
+      hash = "sha256-u9pQUTWOMZH8iew39H2CEI6KRAbt4UfXk4j7avQBxAA=";
+    };
+    "woman_walking.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_walking.mp4";
+      hash = "sha256-CzMTk/iGB+lsJiHYjXe77c8rLDZVhrCI5T0rT11aMXE=";
+    };
     "woman_with_paper.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/woman_with_paper.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_with_paper.mp4";
       hash = "sha256-fFB+Fr6qn+mLJ8JFj40x6T6dG3ek/hKEBb8KaXpgLsg=";
     };
     "woman_with_red_hat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/woman_with_red_hat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_with_red_hat.png";
       hash = "sha256-LI3PVxo1FVwZvx2OgL5ePjDg5erlO0u6CiW1e/uzU7w=";
     };
     "woman_with_sunbeam.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/woman_with_sunbeam.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/woman_with_sunbeam.jpg";
       hash = "sha256-DCarPnniFu6fKDoFGE3VCQYB2VR9Dil+0LAvX2evbR4=";
     };
     "women_with_blue_orb.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/women_with_blue_orb.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/women_with_blue_orb.jpg";
       hash = "sha256-xtwTsjYi2354RNkG80ts7/o0UZBJShK454XK+aqhw20=";
     };
     "women_with_paper.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/women_with_paper.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/women_with_paper.png";
       hash = "sha256-ihT0/qeJpK3B5/ufSbWxTOz2q1p6sPkcgrj1ddRU6g4=";
     };
     "wooden_chair.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wooden_chair.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wooden_chair.png";
       hash = "sha256-QF8EFxGxOBdsVBamuHnwJac6+NnRUqCwlRkicz+KNpU=";
     };
     "wooden_facade_building.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/wooden_facade_building.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/wooden_facade_building.png";
       hash = "sha256-xz+ebhTGH0NM5TiGKT1QKoJYhqB6SiMPW895aPCIEbA=";
     };
     "young_baseball_player.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/young_baseball_player.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/young_baseball_player.png";
       hash = "sha256-1/ajROlYhON/EDmOzRLpK2PufCd8sQgcf9ZAMunMoIQ=";
     };
     "young_woman_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/973f809f04c1339ddc3e86e82506fcc31af25d54/input/young_woman_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2eb719dd43d14c4d96e85ad2c408c665b05d91d9/input/young_woman_portrait.png";
       hash = "sha256-VSQpjPjvM9EqG6BmfTXVGGqyDltCOPRfcTwFyTVJirA=";
     };
   };

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -1,9 +1,9 @@
 {
   comfyui = {
-    version = "0.16.4";
-    releaseDate = "2026-03-07T22:37:49Z";
-    rev = "a7a6335be538f55faa2abf7404c9b8e970847d1f";
-    hash = "sha256-wPPsXQytzpb7gSzE4dUT5JME/q03Z2g6pk9RidHNy8A=";
+    version = "0.17.2";
+    releaseDate = "2026-03-15T02:28:33Z";
+    rev = "040460495c5713b852e4aac29a909aa63b309da7";
+    hash = "sha256-jymf2noIR/QUk7pd1yA3Z+HQ1BZdAVM3Wax91G/d35I=";
   };
 
   vendored = {
@@ -14,45 +14,45 @@
     };
 
     frontendPackage = {
-      version = "1.39.19";
-      url = "https://files.pythonhosted.org/packages/a4/26/de6a7662abbbf8a77bab23f3077530a1bebf55473ff68e67c4086466602f/comfyui_frontend_package-1.39.19-py3-none-any.whl";
-      hash = "sha256-WDQ9157KNxutvjVMErm8R8fcWPf5IkO+U34XjfuvIDY=";
+      version = "1.41.20";
+      url = "https://files.pythonhosted.org/packages/3b/e6/f7222e0c17e1f9a91c4cfa04feb759387bf26edd577ea6a9ca6f8e37a99f/comfyui_frontend_package-1.41.20-py3-none-any.whl";
+      hash = "sha256-dLbXqC5K8V88yDh8KeyATuBuSkWUIjT2lf1QYaUCTjU=";
     };
 
     workflowTemplates = {
-      version = "0.9.11";
-      url = "https://files.pythonhosted.org/packages/eb/8c/45932048be4573d780e055288ae734798f36c3d76e6991f2dd38f4e3aa01/comfyui_workflow_templates-0.9.11-py3-none-any.whl";
-      hash = "sha256-C7CwtGBAkNTaSi2S5S2wRIaKT9ktDCSBmng5erM+cZc=";
+      version = "0.9.21";
+      url = "https://files.pythonhosted.org/packages/3f/26/080d3fb30bea9f91b361d640324ef94cc4ed378616f0427704323b707ac5/comfyui_workflow_templates-0.9.21-py3-none-any.whl";
+      hash = "sha256-qC10QM9IZG6Xmedde4ysYBRl89M1p+eLnAMyIqZmya0=";
     };
 
     workflowTemplatesCore = {
-      version = "0.3.159";
-      url = "https://files.pythonhosted.org/packages/36/43/cee9a36447b51f8d62f3cbd9fbf8db37c0bdf31a1f6f8e270633717520b8/comfyui_workflow_templates_core-0.3.159-py3-none-any.whl";
-      hash = "sha256-d2I/9a29/4WFocJwF+8NNF29PiCntfbmoL1te5piCdE=";
+      version = "0.3.168";
+      url = "https://files.pythonhosted.org/packages/8d/05/c8f8419d31d683263bfdf51295ab79e50dfc5434d6ebf7a4c8fbcb9fbe69/comfyui_workflow_templates_core-0.3.168-py3-none-any.whl";
+      hash = "sha256-viY0lsCIXGIY0yeLqPycGmpmsePwwAfgdQY8gpW6A+w=";
     };
 
     workflowTemplatesMediaApi = {
-      version = "0.3.59";
-      url = "https://files.pythonhosted.org/packages/a2/a0/8de362bdc99cdb8c40329910609f4042a74670e35c29e13c199563ecf8ef/comfyui_workflow_templates_media_api-0.3.59-py3-none-any.whl";
-      hash = "sha256-j2IAb/MByv9kiintlmDlpkpYNHuAfeDvwGd2l5GDNcs=";
+      version = "0.3.64";
+      url = "https://files.pythonhosted.org/packages/d5/f6/47c7e4413bb5e30e3a2788b742ce7f6f6bc162a0ab805b8a7f7962ca8860/comfyui_workflow_templates_media_api-0.3.64-py3-none-any.whl";
+      hash = "sha256-6p4Or4rbuct5B3SDQhoyCGoHGYMvyA7czoTiPxoc9Hc=";
     };
 
     workflowTemplatesMediaVideo = {
-      version = "0.3.57";
-      url = "https://files.pythonhosted.org/packages/f6/cc/dab7b5227e206245aa0566e636031f9b3fa8eb4b9986f4a0a83cf3cff5aa/comfyui_workflow_templates_media_video-0.3.57-py3-none-any.whl";
-      hash = "sha256-A35Ix3AKKFczpWC1wcSLL05OLGj3TiWF0rUUnehcaX8=";
+      version = "0.3.60";
+      url = "https://files.pythonhosted.org/packages/6d/a0/6e915c086938572c6e1ae7f1dcffc3b3b44f9898e9a19f4aa0c66f6c977b/comfyui_workflow_templates_media_video-0.3.60-py3-none-any.whl";
+      hash = "sha256-thoDH1amsg5yfg4eZtlxXSo7ogopctM/SPlraIZP990=";
     };
 
     workflowTemplatesMediaImage = {
-      version = "0.3.98";
-      url = "https://files.pythonhosted.org/packages/81/fd/1989fe77a2cc165231dbd7e65427934a63176f7ad5ba8ee708174af31ac1/comfyui_workflow_templates_media_image-0.3.98-py3-none-any.whl";
-      hash = "sha256-CY7b7bV5ht4uxOYt58pJL5O4oL4DGbtGr2WMEo2SYjg=";
+      version = "0.3.104";
+      url = "https://files.pythonhosted.org/packages/e7/da/200a361d7d6880549c76b0e22bdd03dfea9315a0d920b1b99d15da01aa6e/comfyui_workflow_templates_media_image-0.3.104-py3-none-any.whl";
+      hash = "sha256-GMjU/48YtZcSZYmP8S97+JCJhgh06jX+WJgkbK8taLw=";
     };
 
     workflowTemplatesMediaOther = {
-      version = "0.3.131";
-      url = "https://files.pythonhosted.org/packages/bb/25/b923bad1ffcaea2e28e425e1cd556fd6873bd1cfb7f2686f6bb8f6c08ddd/comfyui_workflow_templates_media_other-0.3.131-py3-none-any.whl";
-      hash = "sha256-zQbi0OC/6vAQmJSZ56cFoJT+479B9maQYiGL6goq4Ko=";
+      version = "0.3.141";
+      url = "https://files.pythonhosted.org/packages/a5/b3/179745959152231283dcae2c4db455c7a07d83b51e933ff193938b8e44e8/comfyui_workflow_templates_media_other-0.3.141-py3-none-any.whl";
+      hash = "sha256-lagRSSPtGVZ3Iq6ecQb6pgFlD9am0bPGKvgaksaSiAQ=";
     };
 
     embeddedDocs = {
@@ -62,22 +62,22 @@
     };
 
     manager = {
-      version = "4.0.5";
-      url = "https://files.pythonhosted.org/packages/e3/e2/9ff20f1f14462ed8c13612a26d274ae4adf916ad495292d50319ad46a619/comfyui_manager-4.0.5-py3-none-any.whl";
-      hash = "sha256-mh4ZGoFzWQemx0WItAu2KhFZPrBoXTwZQICAQBfoi00=";
+      version = "4.1b2";
+      url = "https://files.pythonhosted.org/packages/55/72/94ae1dca446db396d6eadc0549a59e51c3477dc7cda5fbfd4d4ead55e83a/comfyui_manager-4.1b2-py3-none-any.whl";
+      hash = "sha256-JeOFpniZ8gdKBOYoW+20A1M11ou833sFIirVwKLS3Us=";
     };
 
     # New ComfyUI core deps (not in nixpkgs)
     comfyKitchen = {
-      version = "0.2.7";
-      url = "https://files.pythonhosted.org/packages/f8/65/d483613734d0b9753bd9bfa297ff334cb2c7766e82306099db6b259b4e2c/comfy_kitchen-0.2.7-py3-none-any.whl";
-      hash = "sha256-+PqlebadMx0vHqwJ6WqVWGwqa5WKVLwZ5/HBp3hS3TY=";
+      version = "0.2.8";
+      url = "https://files.pythonhosted.org/packages/46/b0/64c3e0656db822cb4f7dbc928d6a13cf2cad861cc178e6386114634e355b/comfy_kitchen-0.2.8-py3-none-any.whl";
+      hash = "sha256-CzIpks8Wgevj1BOseVDznlzEJVBcE8740IUnzoL+XjI=";
     };
 
     comfyAimdo = {
-      version = "0.2.7";
-      url = "https://files.pythonhosted.org/packages/cd/b7/aeb11a92468f97dd2ed1fb7ac25a54d6de9cd252dda0d1fb7d2f131cac4c/comfy_aimdo-0.2.7-py3-none-any.whl";
-      hash = "sha256-+VFU9BDtAbybx2qugbvckHc5srl3VedAuHSGYoxwm5U=";
+      version = "0.2.10";
+      url = "https://files.pythonhosted.org/packages/82/bf/8324fc034d07a975292c2dba2443acbf90e7ff8c30584dfdc286a6d8ee4d/comfy_aimdo-0.2.10-py3-none-any.whl";
+      hash = "sha256-d6eTQS1Q+Z9Ux/73tIaQ0UbuYUseIhyjCBVZUQOsAQ4=";
     };
 
     # UI deps some custom nodes expect

--- a/src/custom_nodes/model_downloader/__init__.py
+++ b/src/custom_nodes/model_downloader/__init__.py
@@ -109,7 +109,11 @@ def setup_js_api(app: Any, *args: Any, **kwargs: Any) -> Any:
     logger.info("Registering model downloader API endpoints")
 
     # Define route patterns to check for
-    route_patterns = ["/api/download-model", "/api/download-progress/", "/api/downloads"]
+    route_patterns = [
+        "/model-downloader/download",
+        "/model-downloader/progress/",
+        "/model-downloader/downloads",
+    ]
 
     # Check if any of our routes already exist
     existing_routes: set[str] = set()
@@ -121,41 +125,33 @@ def setup_js_api(app: Any, *args: Any, **kwargs: Any) -> Any:
                 logger.info("Found existing route matching %s", pattern)
 
     # Register each endpoint if it doesn't already exist
-    if "/api/download-model" not in existing_routes:
-        app.router.add_post("/api/download-model", download_model)
-        logger.info("Registered /api/download-model endpoint")
+    if "/model-downloader/download" not in existing_routes:
+        app.router.add_post("/model-downloader/download", download_model)
+        logger.info("Registered /model-downloader/download endpoint")
 
-    if "/api/download-progress/" not in existing_routes:
-        app.router.add_get("/api/download-progress/{download_id}", get_download_progress)
-        logger.info("Registered /api/download-progress endpoint")
+    if "/model-downloader/progress/" not in existing_routes:
+        app.router.add_get("/model-downloader/progress/{download_id}", get_download_progress)
+        logger.info("Registered /model-downloader/progress endpoint")
 
-    if "/api/downloads" not in existing_routes:
-        app.router.add_get("/api/downloads", list_downloads)
-        logger.info("Registered /api/downloads endpoint")
+    if "/model-downloader/downloads" not in existing_routes:
+        app.router.add_get("/model-downloader/downloads", list_downloads)
+        logger.info("Registered /model-downloader/downloads endpoint")
 
     logger.info("Model downloader API endpoints registered successfully")
     return app
 
 
-# Try to register immediately if PromptServer is available
+# Register routes immediately if PromptServer is available.
+# In ComfyUI v0.17+, setup_js_api may not be called for custom nodes,
+# so we register routes at import time as the primary mechanism.
 try:
     from server import PromptServer  # type: ignore[import-not-found]
-
-    logger.info("Attempting immediate API endpoint registration")
 
     if (
         hasattr(PromptServer, "instance")
         and PromptServer.instance is not None
         and hasattr(PromptServer.instance, "app")
     ):
-        app = PromptServer.instance.app
-        setup_js_api(app)
-    else:
-        logger.warning(
-            "PromptServer.instance not available yet, will register later via setup_js_api"
-        )
-except ImportError:
+        setup_js_api(PromptServer.instance.app)
+except (ImportError, AttributeError):
     logger.debug("PromptServer not available, will register via setup_js_api")
-except AttributeError:
-    logger.exception("Error during immediate API registration")
-    logger.debug("Will try again when ComfyUI calls setup_js_api function")

--- a/src/custom_nodes/model_downloader/js/backend_download.js
+++ b/src/custom_nodes/model_downloader/js/backend_download.js
@@ -1,6 +1,5 @@
 // ComfyUI Model Downloader Frontend Patch
-// This script is the main entry point for the model downloader frontend patch
-// It loads the core component and initializes the downloader
+// This script initializes the model downloader core module
 
 (function() {
   // Initialize the global modelDownloader object if it doesn't exist
@@ -9,62 +8,46 @@
       activeDownloads: {}
     };
   }
-  
-  // Define a function to dynamically load JavaScript files with proper error handling
-  function loadScript(url, callback) {
-    console.log(`[MODEL_DOWNLOADER] Loading script from: ${url}`);
-    const script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.src = url;
-    script.onload = function() {
-      console.log(`[MODEL_DOWNLOADER] Successfully loaded: ${url}`);
-      if (typeof callback === 'function') callback();
-    };
-    script.onerror = function(error) {
-      console.error(`[MODEL_DOWNLOADER] Error loading script from ${url}:`, error);
-    };
-    document.head.appendChild(script);
+
+  // Initialize if core is already loaded (ComfyUI loads all js/ files)
+  if (window.modelDownloaderCoreLoaded && window.modelDownloader &&
+      typeof window.modelDownloader.initialize === 'function') {
+    console.log('[MODEL_DOWNLOADER] Core already loaded, initializing...');
+    window.modelDownloader.initialize();
+    return;
   }
 
-  // Determine the base path for loading modules
+  // Fallback: dynamically load core module if not already available
   function getBasePath() {
-    // Try to find the current script path
     const scripts = document.getElementsByTagName('script');
     for (const script of scripts) {
       if (script.src && script.src.includes('backend_download.js')) {
         return script.src.substring(0, script.src.lastIndexOf('/') + 1);
       }
     }
-    
-    // If not found, try to find any model_downloader script
     for (const script of scripts) {
       if (script.src && script.src.includes('model_downloader')) {
         return script.src.substring(0, script.src.lastIndexOf('/') + 1);
       }
     }
-    
-    // Fallback to extensions path based on current URL
-    const currentUrl = window.location.href;
-    const urlObj = new URL(currentUrl);
+    const urlObj = new URL(window.location.href);
     return `${urlObj.protocol}//${urlObj.host}/extensions/model_downloader/`;
   }
 
-  // Load the core module and initialize the downloader
-  function loadCoreModule() {
-    const basePath = getBasePath();
-    const corePath = basePath + 'model_downloader_core.js';
-    
-    loadScript(corePath, function() {
-      // Initialize the downloader once loaded
-      if (window.modelDownloader && typeof window.modelDownloader.initialize === 'function') {
-        console.log('[MODEL_DOWNLOADER] Initializing model downloader...');
-        window.modelDownloader.initialize();
-      } else {
-        console.error('[MODEL_DOWNLOADER] Failed to initialize - core module not properly loaded');
-      }
-    });
-  }
-  
-  // Start loading the core module
-  loadCoreModule();
+  const basePath = getBasePath();
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.src = basePath + 'model_downloader_core.js';
+  script.onload = function() {
+    if (window.modelDownloader && typeof window.modelDownloader.initialize === 'function') {
+      console.log('[MODEL_DOWNLOADER] Initializing model downloader...');
+      window.modelDownloader.initialize();
+    } else {
+      console.error('[MODEL_DOWNLOADER] Failed to initialize - core module not properly loaded');
+    }
+  };
+  script.onerror = function(error) {
+    console.error('[MODEL_DOWNLOADER] Error loading core script:', error);
+  };
+  document.head.appendChild(script);
 })();

--- a/src/custom_nodes/model_downloader/js/model_downloader_core.js
+++ b/src/custom_nodes/model_downloader/js/model_downloader_core.js
@@ -2,22 +2,16 @@
 // This file contains the core functionality for downloading models
 
 (function() {
-  // Check if this module is already loaded, but don't skip core functionality
-  // We need the patching to work even with duplicates
+  // Check if this module is already loaded
   if (window.modelDownloaderCoreLoaded) {
-    // If the core is already loaded, just make sure the button patching function is still executed
-    if (typeof window.modelDownloader?.patchMissingModelButtons === 'function') {
-      console.log('[MODEL_DOWNLOADER] Core already loaded, re-running button patching');
-      window.modelDownloader.patchMissingModelButtons();
+    if (typeof window.modelDownloader?.interceptBrowserDownloads === 'function') {
+      console.log('[MODEL_DOWNLOADER] Core already loaded');
       return;
     }
   }
   window.modelDownloaderCoreLoaded = true;
   console.log('[MODEL_DOWNLOADER] Loading core functionality');
 
-  // Map to store active downloads
-  const activeDownloads = {};
-  
   // List of trusted domains for model downloads
   const trustedDomains = [
     'huggingface.co',
@@ -27,381 +21,223 @@
     'pixeldrain.com',
     'replicate.delivery'
   ];
-  
-  // Shared disabled-button style constants (used in button init, CSS injection, and updateButtonStatus)
-  const DISABLED_BG = 'rgba(0, 0, 0, 0.45)';
-  const DISABLED_BORDER = 'rgba(255, 255, 255, 0.22)';
-  const DISABLED_TEXT_SHADOW = '0 1px 1px rgba(0, 0, 0, 0.55)';
-  const DISABLED_COLOR = '#fff';
 
-  // Check if a URL is from a trusted domain
   function isTrustedDomain(url) {
     try {
       const urlObj = new URL(url);
       return trustedDomains.some(domain => urlObj.hostname === domain || urlObj.hostname.endsWith('.' + domain));
     } catch (e) {
-      console.error('[MODEL_DOWNLOADER] Error parsing URL:', e);
       return false;
     }
   }
-  
-  // Handle incoming WebSocket messages for our download progress
+
+  // ── Floating progress panel ──────────────────────────────────────────
+  let panelEl = null;
+  let panelBodyEl = null;
+
+  function ensurePanel() {
+    if (panelEl) return;
+
+    // Inject CSS once
+    if (!document.getElementById('mdl-panel-style')) {
+      const css = document.createElement('style');
+      css.id = 'mdl-panel-style';
+      css.textContent = `
+        #mdl-panel {
+          position: fixed; bottom: 16px; right: 16px; z-index: 99999;
+          width: 380px; max-height: 50vh; overflow: hidden;
+          background: #1e1e2e; border: 1px solid #444; border-radius: 10px;
+          box-shadow: 0 8px 32px rgba(0,0,0,.5); font-family: system-ui, sans-serif;
+          display: flex; flex-direction: column; color: #cdd6f4;
+        }
+        #mdl-panel-header {
+          display: flex; align-items: center; justify-content: space-between;
+          padding: 10px 14px; border-bottom: 1px solid #333; flex-shrink: 0;
+        }
+        #mdl-panel-header span { font-size: 13px; font-weight: 600; }
+        #mdl-panel-close {
+          background: none; border: none; color: #888; cursor: pointer;
+          font-size: 18px; line-height: 1; padding: 0 4px;
+        }
+        #mdl-panel-close:hover { color: #cdd6f4; }
+        #mdl-panel-body {
+          overflow-y: auto; padding: 8px 14px 12px; flex: 1;
+        }
+        .mdl-row {
+          display: flex; flex-direction: column; gap: 4px;
+          padding: 8px 0; border-bottom: 1px solid #333;
+        }
+        .mdl-row:last-child { border-bottom: none; }
+        .mdl-row-name {
+          font-size: 12px; font-weight: 500; white-space: nowrap;
+          overflow: hidden; text-overflow: ellipsis; color: #cdd6f4;
+        }
+        .mdl-row-bar-bg {
+          height: 6px; border-radius: 3px; background: #313244; overflow: hidden;
+        }
+        .mdl-row-bar {
+          height: 100%; border-radius: 3px; background: #89b4fa;
+          transition: width .3s ease;
+        }
+        .mdl-row-bar.done { background: #a6e3a1; }
+        .mdl-row-bar.fail { background: #f38ba8; }
+        .mdl-row-info {
+          display: flex; justify-content: space-between;
+          font-size: 11px; color: #888;
+        }
+      `;
+      document.head.appendChild(css);
+    }
+
+    panelEl = document.createElement('div');
+    panelEl.id = 'mdl-panel';
+    panelEl.innerHTML = `
+      <div id="mdl-panel-header">
+        <span>Model Downloads</span>
+        <button id="mdl-panel-close" title="Minimize">&minus;</button>
+      </div>
+      <div id="mdl-panel-body"></div>`;
+    document.body.appendChild(panelEl);
+    panelBodyEl = panelEl.querySelector('#mdl-panel-body');
+    panelEl.querySelector('#mdl-panel-close').addEventListener('click', () => {
+      panelEl.style.display = 'none';
+    });
+  }
+
+  function getOrCreateRow(downloadId, filename) {
+    ensurePanel();
+    panelEl.style.display = '';
+    let row = panelBodyEl.querySelector(`[data-dl-id="${downloadId}"]`);
+    if (!row) {
+      row = document.createElement('div');
+      row.className = 'mdl-row';
+      row.setAttribute('data-dl-id', downloadId);
+      row.innerHTML = `
+        <div class="mdl-row-name" title="${filename}">${filename}</div>
+        <div class="mdl-row-bar-bg"><div class="mdl-row-bar" style="width:0%"></div></div>
+        <div class="mdl-row-info"><span class="mdl-pct">0%</span><span class="mdl-speed"></span></div>`;
+      panelBodyEl.appendChild(row);
+    }
+    return row;
+  }
+
+  function updateRow(downloadId, data) {
+    const row = panelBodyEl?.querySelector(`[data-dl-id="${downloadId}"]`);
+    if (!row) return;
+    const bar = row.querySelector('.mdl-row-bar');
+    const pctEl = row.querySelector('.mdl-pct');
+    const speedEl = row.querySelector('.mdl-speed');
+
+    if (data.status === 'completed') {
+      bar.style.width = '100%';
+      bar.classList.add('done');
+      pctEl.textContent = 'Complete';
+      speedEl.textContent = '';
+    } else if (data.status === 'error') {
+      bar.classList.add('fail');
+      pctEl.textContent = 'Failed';
+      speedEl.textContent = data.error || '';
+    } else {
+      const pct = Math.round(data.percent || 0);
+      bar.style.width = pct + '%';
+      pctEl.textContent = pct + '%';
+      speedEl.textContent = data.speed ? (data.speed + ' MB/s') : '';
+    }
+  }
+
+  function checkAllDone() {
+    if (!window.modelDownloader?.activeDownloads) return;
+    const all = Object.values(window.modelDownloader.activeDownloads);
+    if (all.length === 0) return;
+    const done = all.every(d => d.status === 'completed' || d.status === 'error');
+    if (done) {
+      // Auto-hide panel after 8 seconds when all downloads finish
+      setTimeout(() => {
+        if (panelEl) panelEl.style.display = 'none';
+      }, 8000);
+    }
+  }
+
+  // ── Directory guessing from DOM ──────────────────────────────────────
+  function guessDirectoryFromDom(filename) {
+    const candidates = document.querySelectorAll('p[title]');
+    for (const el of candidates) {
+      if (el.title !== filename && !el.textContent.trim().startsWith(filename)) continue;
+      let node = el.parentElement;
+      for (let i = 0; i < 10 && node; i++) {
+        const header = node.querySelector('.text-destructive-background-hover');
+        if (header) {
+          const match = header.textContent.trim().match(/^(\S+)/);
+          if (match) return match[1];
+        }
+        node = node.parentElement;
+      }
+    }
+    const headers = document.querySelectorAll('.text-destructive-background-hover');
+    if (headers.length === 1) {
+      const match = headers[0].textContent.trim().match(/^(\S+)/);
+      if (match) return match[1];
+    }
+    return 'checkpoints';
+  }
+
+  // ── WebSocket message handler ────────────────────────────────────────
   function handleMessageEvent(event) {
     try {
-      // Extract data from the event (different ComfyUI versions may structure this differently)
       let messageData = event.data || event;
-      
-      // If this is a wrapper message with a type and data property (standard format)
       if (messageData && messageData.type === 'model_download_progress' && messageData.data) {
         messageData = messageData.data;
       }
-      
-      // Handle CustomEvent format used by addEventListener
       if (messageData && messageData.detail) {
-        if (messageData.detail.data) {
-          // Event comes as {detail: {type: 'model_download_progress', data: {...}}}
-          messageData = messageData.detail.data;
-        } else {
-          // Event comes as {detail: {download_id: '...', status: '...'}}
-          messageData = messageData.detail;
-        }
+        messageData = messageData.detail.data || messageData.detail;
       }
-      
-      if (messageData && messageData.download_id && window.modelDownloader) {
-        // Process download update
-        
-        // Create array to store all matched buttons
-        let matchedButtons = [];
-        let downloadData = null;
-        
-        // Only search active downloads if they exist
-        if (window.modelDownloader.activeDownloads) {
-          // Look for the download by server download ID
-          downloadData = window.modelDownloader.activeDownloads[messageData.download_id];
-          
-          // If not found directly, check all active downloads for a matching server_download_id
-          if (!downloadData) {
-            Object.values(window.modelDownloader.activeDownloads).forEach(download => {
-              if (download.server_download_id === messageData.download_id) {
-                downloadData = download;
-              }
-            });
-          }
-          
-          // If we found download data with a button, add it to matches
-          if (downloadData && downloadData.button) {
-            matchedButtons.push(downloadData.button);
-          }
+
+      if (!messageData || !messageData.download_id || !window.modelDownloader) return;
+
+      const downloads = window.modelDownloader.activeDownloads || {};
+      let downloadData = downloads[messageData.download_id];
+      if (!downloadData) {
+        Object.values(downloads).forEach(d => {
+          if (d.server_download_id === messageData.download_id) downloadData = d;
+        });
+      }
+
+      if (downloadData) {
+        Object.assign(downloadData, {
+          percent: messageData.percent || 0,
+          speed: messageData.speed || 0,
+          status: messageData.status || 'downloading',
+          error: messageData.error || null
+        });
+      }
+
+      // Update the progress panel row
+      updateRow(messageData.download_id, messageData);
+
+      if (messageData.status === 'completed' || messageData.status === 'error') {
+        if (downloadData) downloadData.status = messageData.status;
+        if (!window.modelDownloader.completedDownloads) {
+          window.modelDownloader.completedDownloads = {};
         }
-        
-        // Search for button by data attribute as a backup
-        if (document.querySelector) {
-          const buttonByAttribute = document.querySelector(`button[data-download-id="${messageData.download_id}"]`);
-          if (buttonByAttribute) {
-            matchedButtons.push(buttonByAttribute);
-          }
-        }
-        
-        // Search through all buttons for any with metadata that might match
-        if (document.querySelectorAll) {
-          const allButtons = document.querySelectorAll('button[data-model-downloader-patched="true"]');
-          for (const btn of allButtons) {
-            const folder = btn.getAttribute('data-folder-name');
-            const filename = btn.getAttribute('data-file-name');
-            
-            if (folder && filename && messageData.folder && messageData.filename) {
-              // Check if this button's metadata matches the download metadata
-              if (folder === messageData.folder && filename === messageData.filename) {
-                matchedButtons.push(btn);
-              }
-            }
-          }
-        }
-        
-        // Update all matched buttons
-        if (matchedButtons.length > 0) {
-          matchedButtons.forEach(button => {
-            // If message contains total_size, store it on the button for later
-            if (messageData.total_size) {
-              button.setAttribute('data-total-size', messageData.total_size);
-            }
-            
-            // Update our tracking object with all message data
-            if (downloadData) {
-              // Copy all properties from the message to our tracking object
-              Object.assign(downloadData, {
-                percent: messageData.percent || 0,
-                downloaded: messageData.downloaded || 0,
-                total_size: messageData.total_size || 0,
-                speed: messageData.speed || 0,
-                eta: messageData.eta || 0,
-                status: messageData.status || 'downloading',
-                error: messageData.error || null
-              });
-            }
-            
-            if (messageData.status === 'completed') {
-              updateButtonStatus(button, 'completed');
-              // Update status in activeDownloads tracking
-              if (downloadData) {
-                downloadData.status = 'completed';
-              }
-              // Check if all downloads are complete to close the dialog
-              checkAndCloseDialog();
-            } else if (messageData.status === 'error') {
-              updateButtonStatus(button, 'error', messageData.error);
-              // Update status in activeDownloads tracking
-              if (downloadData) {
-                downloadData.status = 'error';
-              }
-              // Check if all downloads are complete to close the dialog
-              checkAndCloseDialog();
-            } else {
-              // For in-progress downloads, update button with downloading status and information
-              updateButtonStatus(button, 'downloading');
-            }
-          });
-        } else {
-          // Store status for later if no button found
-          if (messageData.status === 'completed' || messageData.status === 'error') {
-            // Store in cache for later use
-            if (!window.modelDownloader.completedDownloads) {
-              window.modelDownloader.completedDownloads = {};
-            }
-            window.modelDownloader.completedDownloads[messageData.download_id] = messageData;
-            
-            // Update status in activeDownloads if we can find it
-            if (window.modelDownloader.activeDownloads && 
-                window.modelDownloader.activeDownloads[messageData.download_id]) {
-              window.modelDownloader.activeDownloads[messageData.download_id].status = messageData.status;
-              // Check if all downloads are complete to close the dialog
-              checkAndCloseDialog();
-            }
-          }
-        }
+        window.modelDownloader.completedDownloads[messageData.download_id] = messageData;
+        checkAllDone();
       }
     } catch (error) {
       console.error('[MODEL_DOWNLOADER] Error handling message event:', error);
     }
   }
-  
-  // Check if all active downloads are complete and close the dialog if appropriate
-  function checkAndCloseDialog() {
-    // Don't do anything if there are no active downloads
-    if (!window.modelDownloader || !window.modelDownloader.activeDownloads) {
-      return;
-    }
-    
-    // First, check if there are any active downloads still in progress
-    const activeDownloads = window.modelDownloader.activeDownloads;
-    const activeDownloadIds = Object.keys(activeDownloads);
-    
-    // If no active downloads, nothing to check
-    if (activeDownloadIds.length === 0) {
-      return;
-    }
-    
-    // Check if all downloads are either completed or failed
-    const allComplete = activeDownloadIds.every(id => {
-      const download = activeDownloads[id];
-      return download.status === 'completed' || download.status === 'error';
-    });
-    
-    if (allComplete) {
-      console.log('[MODEL_DOWNLOADER] All downloads complete, attempting to close dialog');
-      
-      try {
-        // Find and access the Pinia dialog store which is where ComfyUI manages dialogs
-        let dialogStore = null;
-        
-        // Method 1: Try to find the dialog store in the Pinia instance
-        if (window?.$pinia?.state?.value?.dialog) {
-          console.log('[MODEL_DOWNLOADER] Found dialog store in Pinia state');
-          dialogStore = window?.$pinia?._s?.get('dialog');
-        }
-        
-        // Method 2: Check if app has store with direct dialog store reference
-        if (!dialogStore && window.app?.store?.dialog) {
-          console.log('[MODEL_DOWNLOADER] Found dialog store in app.store');
-          dialogStore = window.app.store.dialog;
-        }
-        
-        // Method 3: Check for a direct dialogStore property on app
-        if (!dialogStore && window.app?.dialogStore) {
-          console.log('[MODEL_DOWNLOADER] Found dialogStore in app');
-          dialogStore = window.app.dialogStore;
-        }
-        
-        // If we found a dialog store, try to close the dialog
-        if (dialogStore && typeof dialogStore.closeDialog === 'function') {
-          console.log('[MODEL_DOWNLOADER] Calling closeDialog on dialog store');
-          dialogStore.closeDialog({ key: 'global-missing-models-warning' });
-          
-          // Show a toast notification if available
-          if (window.app && typeof window.app.ui?.showToast === 'function') {
-            window.app.ui.showToast('All model downloads completed!', 3000, 0);
-          }
-          return;
-        }
-        
-        // Method 3: Look for PrimeVue dialog in the DOM
-        const primeVueDialog = document.querySelector('.p-dialog.global-dialog');
-        if (primeVueDialog && primeVueDialog.textContent.includes('Missing Models')) {
-          console.log('[MODEL_DOWNLOADER] Found PrimeVue dialog, attempting to close it');
-          
-          // Try to find and click the close button
-          const closeButton = primeVueDialog.querySelector('.p-dialog-header-close, .p-dialog-close-button');
-          if (closeButton) {
-            console.log('[MODEL_DOWNLOADER] Clicking close button on PrimeVue dialog');
-            closeButton.click();
-            
-            // Show a toast notification if available
-            if (window.app && typeof window.app.ui?.showToast === 'function') {
-              window.app.ui.showToast('All model downloads completed!', 3000, 0);
-            }
-            return;
-          }
-          
-          // If no close button found, try to hide the dialog
-          primeVueDialog.style.display = 'none';
-          return;
-        }
-        
-        // Method 4: Try to find the dialog in DOM and close it manually (fallback)
-        const dialogSelectors = [
-          '.comfy-modal.open',
-          '.sp-container dialog[open]',
-          '.comfy-menu dialog[open]', 
-          'div[id^="dialog"] dialog[open]',
-          'div.dialog dialog[open]',
-          'dialog[open]'
-        ];
-        
-        // Find the missing models dialog
-        for (const selector of dialogSelectors) {
-          const dialogs = document.querySelectorAll(selector);
-          for (const dialog of dialogs) {
-            if (dialog.textContent && dialog.textContent.includes('Missing Models')) {
-              // Close the dialog
-              console.log('[MODEL_DOWNLOADER] Closing dialog via DOM as all downloads are complete');
-              if (typeof dialog.close === 'function') {
-                dialog.close();
-              } else if (dialog.style) {
-                dialog.style.display = 'none';
-              }
-              
-              // Show a toast notification if available
-              if (window.app && typeof window.app.ui?.showToast === 'function') {
-                window.app.ui.showToast('All model downloads completed!', 3000, 0);
-              } else if (typeof window.toastr?.success === 'function') {
-                window.toastr.success('All model downloads completed!');
-              }
-              
-              return;
-            }
-          }
-        }
-        
-        // Method 5: Last resort - try to programmatically trigger Escape key to close modal
-        console.log('[MODEL_DOWNLOADER] Attempting to use Escape key to close dialog');
-        const escapeEvent = new KeyboardEvent('keydown', {
-          key: 'Escape',
-          code: 'Escape',
-          keyCode: 27,
-          which: 27,
-          bubbles: true,
-          cancelable: true
-        });
-        document.dispatchEvent(escapeEvent);
-        
-      } catch (error) {
-        console.error('[MODEL_DOWNLOADER] Error trying to close dialog:', error);
-      }
-    }
-  }
 
-  // Function to download model using backend API
+  // ── Backend download API ─────────────────────────────────────────────
   async function downloadModelWithBackend(url, folder, filename, button) {
-    // Start download process
-    
-    // Message handlers are registered in model_downloader.js
-    
-    // Create a unique client ID for tracking
     const clientDownloadId = `${folder}_${filename}_${Date.now()}`;
-    
-    // Add a data attribute to the button for easy lookup
-    if (button) {
-      button.setAttribute('data-download-id', clientDownloadId);
-    }
-    
-    // Disable button and show spinner
-    if (button) {
-      button.disabled = true;
-      button.innerHTML = '<span class="spinner"></span> Downloading...';
-      button.style.cursor = 'not-allowed';
 
-      // Improve contrast for disabled button styling in newer ComfyUI/PrimeVue themes
-      button.style.opacity = '1';
-      button.style.color = DISABLED_COLOR;
-      button.style.backgroundColor = DISABLED_BG;
-      button.style.borderColor = DISABLED_BORDER;
-      button.style.textShadow = DISABLED_TEXT_SHADOW;
-      
-      // Store original button text in case we need to revert
-      button.setAttribute('data-original-text', button.textContent || 'Download with Model Downloader');
-      
-      // Add spinner CSS if not already added
-      if (!document.getElementById('model-downloader-spinner-style')) {
-        const style = document.createElement('style');
-        style.id = 'model-downloader-spinner-style';
-        style.textContent = `
-          .spinner {
-            display: inline-block;
-            width: 12px;
-            height: 12px;
-            border: 2px solid rgba(255, 255, 255, 0.3);
-            border-radius: 50%;
-            border-top-color: white;
-            animation: spin 1s ease-in-out infinite;
-            margin-right: 8px;
-          }
-          @keyframes spin {
-            to {
-              transform: rotate(360deg);
-            }
-          }
-        `;
-        document.head.appendChild(style);
-      }
+    // Create the progress panel row immediately
+    getOrCreateRow(clientDownloadId, filename);
 
-      // Improve contrast for the progress pill/button in the PrimeVue/ComfyUI theme.
-      // Some themes apply opacity + dimmed colors to disabled buttons and make the
-      // progress text nearly invisible. Override with !important.
-      if (!document.getElementById('model-downloader-contrast-style')) {
-        const style = document.createElement('style');
-        style.id = 'model-downloader-contrast-style';
-        style.textContent = `
-          button.model-downloader-patched:disabled,
-          .model-downloader-patched[disabled] {
-            opacity: 1 !important;
-            filter: none !important;
-            color: ${DISABLED_COLOR} !important;
-            background-color: ${DISABLED_BG} !important;
-            border-color: ${DISABLED_BORDER} !important;
-            text-shadow: ${DISABLED_TEXT_SHADOW} !important;
-          }
-        `;
-        document.head.appendChild(style);
-      }
-    }
-    
-    // Store in the global object for tracking
-    if (!window.modelDownloader) {
-      window.modelDownloader = {};
-    }
-    if (!window.modelDownloader.activeDownloads) {
-      window.modelDownloader.activeDownloads = {};
-    }
+    if (!window.modelDownloader) window.modelDownloader = {};
+    if (!window.modelDownloader.activeDownloads) window.modelDownloader.activeDownloads = {};
+    if (!window.modelDownloader.completedDownloads) window.modelDownloader.completedDownloads = {};
+
     window.modelDownloader.activeDownloads[clientDownloadId] = {
       button: button,
       url: url,
@@ -409,503 +245,96 @@
       filename: filename,
       status: 'downloading'
     };
-    
-    // Initialize completedDownloads cache if needed
-    if (!window.modelDownloader.completedDownloads) {
-      window.modelDownloader.completedDownloads = {};
-    }
-    
+
     try {
-      // Prepare request data as JSON instead of FormData for better compatibility
-      const jsonData = {
-        url: url,
-        folder: folder,
-        filename: filename
-      };
-      
-      console.log('[MODEL_DOWNLOADER] Sending download request with data:', jsonData);
-      
-      // Server request that returns immediately while download continues in background
-      const response = await fetch('/api/download-model', {
+      const jsonData = { url, folder, filename };
+      console.log('[MODEL_DOWNLOADER] Sending download request:', jsonData);
+
+      const response = await fetch('/model-downloader/download', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(jsonData)
       });
-      
+
       if (!response.ok) {
         const errorText = await response.text();
         throw new Error(`Server responded with ${response.status}: ${errorText}`);
       }
-      
+
       const result = await response.json();
-      
+
       if (result.success) {
-        // Download successfully initiated
-        
-        // Store the server-assigned download ID for future reference
+        // Map server download ID to our tracking
         if (window.modelDownloader.activeDownloads[clientDownloadId]) {
           window.modelDownloader.activeDownloads[clientDownloadId].server_download_id = result.download_id;
         }
-        
-        // Also store with the server's download ID for easier lookup
         window.modelDownloader.activeDownloads[result.download_id] = {
-          button: button,
-          url: url,
-          folder: folder,
-          filename: filename,
+          button: button, url, folder, filename,
           status: 'downloading',
           client_id: clientDownloadId
         };
-        
-        // Update button with server download ID for direct matching
-        if (button) {
-          button.setAttribute('data-download-id', result.download_id);
-          button.setAttribute('data-server-download-id', result.download_id);
-          button.setAttribute('data-client-download-id', clientDownloadId);
-        }
-        
-        // Check if we already have a completed status for this download in our cache
-        if (window.modelDownloader.completedDownloads && 
-            window.modelDownloader.completedDownloads[result.download_id]) {
-            
-          const cachedResult = window.modelDownloader.completedDownloads[result.download_id];
-          console.log('[MODEL_DOWNLOADER] Found cached completion status:', cachedResult.status);
-          
-          // Apply the cached status
-          if (cachedResult.status === 'completed') {
-            console.log('[MODEL_DOWNLOADER] Applying cached completed status');
-            updateButtonStatus(button, 'completed');
-          } else if (cachedResult.status === 'error') {
-            console.log('[MODEL_DOWNLOADER] Applying cached error status');
-            updateButtonStatus(button, 'error', cachedResult.error);
-          }
-        }
-        
+
+        // Also update the panel row's data-dl-id to match the server ID
+        // so WebSocket updates find it
+        const row = panelBodyEl?.querySelector(`[data-dl-id="${clientDownloadId}"]`);
+        if (row) row.setAttribute('data-dl-id', result.download_id);
+
         return result;
       } else if (result.error) {
         throw new Error(result.error);
       }
-      
       return result;
     } catch (error) {
       console.error('[MODEL_DOWNLOADER] Download request failed:', error.message);
-      
-      // Update button with error
-      updateButtonStatus(button, 'error', error.message);
-      
+      updateRow(clientDownloadId, { status: 'error', error: error.message });
+      if (window.modelDownloader.activeDownloads[clientDownloadId]) {
+        window.modelDownloader.activeDownloads[clientDownloadId].status = 'error';
+      }
       throw error;
     }
   }
 
-// Update the button status based on download status
-function updateButtonStatus(button, status, errorMessage) {
-  if (!button) return;
-  
-  if (status === 'completed') {
-    button.disabled = true;
+  // ── Intercept browser-initiated model downloads ──────────────────────
+  function interceptBrowserDownloads() {
+    const originalClick = HTMLAnchorElement.prototype.click;
 
-    // Just show "Downloaded" when complete, no file size
-    button.innerHTML = 'Downloaded';
+    HTMLAnchorElement.prototype.click = function() {
+      if (this.download && this.href && !this.isConnected && isTrustedDomain(this.href)) {
+        const url = this.href;
+        const filename = this.download || url.split('/').pop() || 'model';
+        const folder = guessDirectoryFromDom(filename);
 
-    // Keep original styling - don't change color
-    button.style.cursor = 'default';
-    button.setAttribute('data-download-status', 'completed');
-    // Show a toast notification for download completion if possible
-    if (window.app && typeof window.app.ui?.showToast === 'function') {
-      window.app.ui.showToast('Model download completed!', 3000, 0);
-    } else if (typeof window.toastr?.success === 'function') {
-      window.toastr.success('Model download completed!');
-    } else {
-      console.log('[MODEL_DOWNLOADER] Download completed');
-    }
-  } else if (status === 'downloading') {
-    // For downloading status, get the download info from our tracking object
-    const downloadId = button.getAttribute('data-download-id');
-    if (downloadId && downloadId in window.modelDownloader.activeDownloads) {
-      const downloadInfo = window.modelDownloader.activeDownloads[downloadId];
+        console.log('[MODEL_DOWNLOADER] Intercepted browser download:', { url, filename, folder });
 
-      // Display percentage
-      let statusText = `${downloadInfo.percent || 0}%`;
-
-      // Add speed if available
-      if (downloadInfo.speed) {
-        statusText += ` (${downloadInfo.speed} MB/s)`;
-      }
-
-      // Add ETA if available
-      if (downloadInfo.eta) {
-        const etaMinutes = Math.floor(downloadInfo.eta / 60);
-        const etaSeconds = downloadInfo.eta % 60;
-        statusText += ` - ${etaMinutes}m ${etaSeconds}s remaining`;
-      }
-
-      button.innerHTML = statusText;
-    } else {
-      // Fallback if we don't have detailed info
-      button.innerHTML = errorMessage || 'Downloading...';
-    }
-
-    button.disabled = true;
-    button.style.cursor = 'default';
-
-    // Improve contrast for disabled button styling in newer ComfyUI/PrimeVue themes
-    // (keep it inline too, in case the CSS injection above loads late)
-    button.style.setProperty('opacity', '1', 'important');
-    button.style.setProperty('filter', 'none', 'important');
-    button.style.setProperty('color', DISABLED_COLOR, 'important');
-    button.style.setProperty('background-color', DISABLED_BG, 'important');
-    button.style.setProperty('border-color', DISABLED_BORDER, 'important');
-    button.style.setProperty('text-shadow', DISABLED_TEXT_SHADOW, 'important');
-
-    button.setAttribute('data-download-status', 'downloading');
-  } else if (status === 'error') {
-    button.disabled = false;
-    button.innerHTML = '❌ Failed - Try Again';
-    button.style.backgroundColor = '#F44336';
-    button.style.cursor = 'pointer';
-    button.title = errorMessage || 'Download failed';
-    button.setAttribute('data-download-status', 'error');
-    // Show error notification if possible
-    if (window.app && typeof window.app.ui?.showToast === 'function') {
-      window.app.ui.showToast('Download failed: ' + (errorMessage || 'Unknown error'), 5000, 2);
-    } else if (typeof window.toastr?.error === 'function') {
-      window.toastr.error('Download failed: ' + (errorMessage || 'Unknown error'));
-    } else {
-      console.error('[MODEL_DOWNLOADER] Download failed:', errorMessage || 'Unknown error');
-    }
-  } 
-}
-
-// Patch the download buttons in the missing models dialog
-function patchMissingModelButtons() {
-  // Set up missing model button patching
-  
-  // ... rest of the code remains the same ...
-    // Selectors for finding dialogs and buttons
-    const dialogSelectors = [
-      '.p-dialog.global-dialog',  // ComfyUI missing models dialog
-      '.p-dialog',                // Any PrimeVue dialog
-      '#nodes-modal',            // Old-style ComfyUI modal
-      'div[role="dialog"]',      // Generic dialog role
-      '.p-dialog-content',       // PrimeVue dialog content
-      '.dialog'                  // Generic dialog class
-    ];
-    
-    const buttonSelectors = [
-      '.p-button[title*="http"]',                 // PrimeVue buttons with URL in title
-      'button[title*="http"]',                    // Regular buttons with URL in title
-      '.comfy-missing-models button',             // Buttons in missing models list
-      '.p-listbox.comfy-missing-models .p-button', // ListBox buttons
-      'button:not([data-model-downloader-patched])', // Any button not already patched
-      '.p-button',                                // Any PrimeVue button
-      'a.p-button',                              // PrimeVue button links
-      '.p-dialog button'                         // Any button in a dialog
-    ];
-    
-    // Combined selectors
-    const dialogSelector = dialogSelectors.join(', ');
-    const buttonSelector = buttonSelectors.join(', ');
-    
-    // Function to find and patch all download buttons
-    function patchAllButtons() {
-      let patchedCount = 0;
-      
-      // Find all dialogs that could be missing models dialogs
-      document.querySelectorAll(dialogSelector).forEach(dialog => {
-        // Check if this looks like a missing models dialog
-        if (dialog.textContent && dialog.textContent.includes('Missing Models')) {
-          
-          // Find all potential download buttons in this dialog
-          const buttons = dialog.querySelectorAll(buttonSelector);
-          
-          // Process each button
-          buttons.forEach(button => {
-            // Skip already patched buttons
-            if (button.hasAttribute('data-model-downloader-patched')) {
-              return;
-            }
-            
-            // Check if this looks like a download button
-            const buttonText = button.textContent || '';
-            const buttonTitle = button.getAttribute('title') || '';
-            
-            if ((buttonText.includes('Download') || 
-                (button.tagName === 'BUTTON' && dialog.textContent.includes('Missing Models'))) &&
-                (buttonTitle.includes('http') || button.getAttribute('href')?.includes('http'))) {
-              
-              // Mark button as patched
-              button.setAttribute('data-model-downloader-patched', 'true');
-              
-              // Extract information from the dialog
-              let modelUrl = buttonTitle;
-              let folderName = '';
-              let fileName = '';
-              
-              // Try multiple sources to find the URL
-              if (!modelUrl.includes('http')) {
-                // Look for href attributes that might contain the URL
-                const closestLink = button.closest('a[href]');
-                if (closestLink && closestLink.href.includes('http')) {
-                  modelUrl = closestLink.href;
-                } else {
-                  // Look for text that resembles a URL in the dialog
-                  const dialogText = dialog.textContent;
-                  const urlMatch = dialogText.match(/(https?:\/\/[^\s]+)/);
-                  if (urlMatch) {
-                    modelUrl = urlMatch[0];
-                  }
-                }
-              }
-              
-              // Try to find the folder/filename information
-              const listItem = button.closest('li');
-              if (listItem) {
-                // Look for a span with title that might contain path info
-                const pathSpan = listItem.querySelector('span[title]');
-                if (pathSpan) {
-                  const pathText = pathSpan.textContent;
-                  if (pathText && pathText.includes('/')) {
-                    const parts = pathText.split('/');
-                    folderName = parts[0].trim();
-                    fileName = parts.slice(1).join('/').trim();
-                  }
-                }
-              }
-              
-              // If we still don't have a filename, extract from URL
-              if (!fileName && modelUrl && modelUrl.includes('http')) {
-                try {
-                  const urlObj = new URL(modelUrl);
-                  const pathParts = urlObj.pathname.split('/');
-                  fileName = pathParts[pathParts.length - 1] || 'downloaded_model';
-                } catch (e) {
-                  console.error('[MODEL_DOWNLOADER] Error parsing URL:', e);
-                }
-              }
-              
-              // Fallback for folder name
-              if (!folderName) {
-                // Look for common model folder names in the dialog text
-                const dialogText = dialog.textContent.toLowerCase();
-                const folderHints = ['checkpoints', 'loras', 'vae', 'upscale', 'controlnet', 'embedding', 'clip'];
-                
-                for (const hint of folderHints) {
-                  if (dialogText.includes(hint)) {
-                    folderName = hint;
-                    break;
-                  }
-                }
-              }
-              
-              // Create a new button
-              const newButton = document.createElement('button');
-              
-              // Copy all the important attributes
-              newButton.className = button.className;
-              newButton.style.cssText = button.style.cssText;
-              newButton.type = 'button';
-              newButton.title = button.title;
-              // Try to get the model size from various places
-              let sizeText = '';
-              const parent = button.parentElement;
-              const modelListItem = button.closest('li');
-              
-              // First check the button's own text or title
-              const buttonTextMatch = (button.textContent || '').match(/(\d+(?:\.\d+)?)\s*(MB|GB)/i);
-              const buttonTitleMatch = (button.title || '').match(/(\d+(?:\.\d+)?)\s*(MB|GB)/i);
-              
-              // Then check parent element
-              const parentMatch = parent && parent.textContent ? 
-                parent.textContent.match(/(\d+(?:\.\d+)?)\s*(MB|GB)/i) : null;
-                
-              // Check list item if available
-              const listItemMatch = modelListItem && modelListItem.textContent ? 
-                modelListItem.textContent.match(/(\d+(?:\.\d+)?)\s*(MB|GB)/i) : null;
-                
-              // Check dialog text
-              const dialogTextMatch = dialog.textContent ? 
-                dialog.textContent.match(/(\d+(?:\.\d+)?)\s*(MB|GB)/i) : null;
-              
-              // Use the first match found
-              const match = buttonTextMatch || buttonTitleMatch || parentMatch || listItemMatch || dialogTextMatch;
-              if (match) {
-                sizeText = ` (${match[0]})`;
-              } else {
-                // If no size found, try to fetch size from the URL
-                console.log('[MODEL_DOWNLOADER] No size found, will display size after fetching metadata');
-              }
-              
-              newButton.textContent = `Download with Model Downloader${sizeText}`;
-              
-              // Mark as patched
-              newButton.setAttribute('data-model-downloader-patched', 'true');
-              newButton.classList.add('model-downloader-patched');
-              
-              // Store the URL
-              newButton.setAttribute('data-model-url', modelUrl);
-              newButton.setAttribute('data-folder-name', folderName);
-              newButton.setAttribute('data-file-name', fileName);
-              
-              // Create download handler function
-              const downloadHandler = function(e) {
-                // Prevent default browser download behavior
-                if (e) {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }
-                
-                // Get the URL directly from the button attributes
-                const url = newButton.getAttribute('data-model-url') || newButton.getAttribute('title') || '';
-                let folder = newButton.getAttribute('data-folder-name') || '';
-                let filename = newButton.getAttribute('data-file-name') || '';
-                
-                // Prompt for missing info if needed
-                if (!url || !url.includes('http')) {
-                  alert('Could not determine download URL. Please download manually.');
-                  return;
-                }
-                
-                if (!folder) {
-                  folder = prompt('Please specify the model folder type:', 'checkpoints');
-                  if (!folder) {
-                    return;
-                  }
-                }
-                
-                // Extract filename from URL if not already set
-                if (!filename && url) {
-                  try {
-                    const urlObj = new URL(url);
-                    const pathParts = urlObj.pathname.split('/');
-                    filename = pathParts[pathParts.length - 1] || 'downloaded_model';
-                  } catch (e) {
-                    filename = 'downloaded_model';
-                  }
-                }
-                
-                // Call our backend download API with the button instance so it can be updated
-                downloadModelWithBackend(url, folder, filename, newButton)
-                  .catch(error => {
-                    console.error('[MODEL_DOWNLOADER] Download error:', error);
-                  });
-              };
-              
-              // Set click handler
-              newButton.addEventListener('click', downloadHandler);
-              
-              // Replace the old button with our new one
-              if (button.parentNode) {
-                button.parentNode.replaceChild(newButton, button);
-              }
-              
-              // Count patched buttons
-              patchedCount++;
-            }
+        downloadModelWithBackend(url, folder, filename, null)
+          .then(() => {
+            console.log('[MODEL_DOWNLOADER] Backend download started for:', filename);
+          })
+          .catch(err => {
+            console.error('[MODEL_DOWNLOADER] Backend download failed, falling back to browser:', err);
+            originalClick.call(this);
           });
-        }
-      });
-    }
-    
-    // Patch immediately once
-    patchAllButtons();
-    
-    // Set up mutation observer to catch dynamically created dialogs
-    const observer = new MutationObserver(function(mutations) {
-      for (const mutation of mutations) {
-        if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-          for (const node of mutation.addedNodes) {
-            if (node.nodeType === Node.ELEMENT_NODE) {
-              // Check if this node or any of its children match our dialog selectors
-              const isDialog = (node.matches && node.matches(dialogSelector)) || 
-                  (node.querySelector && node.querySelector(dialogSelector));
-                  
-              // Or if it has "Missing Models" in its text content
-              const hasMissingModels = node.textContent && node.textContent.includes('Missing Models');
-              
-              if (isDialog || hasMissingModels) {
-                patchAllButtons();
-                return;
-              }
-            }
-          }
-        }
+        return;
       }
-    });
-    
-    // Observe the entire document body for changes
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['style', 'class']
-    });
-    
-    // Also poll occasionally for dialogs that might have been missed
-    const pollInterval = setInterval(function() {
-      const dialogs = document.querySelectorAll(dialogSelector);
-      for (const dialog of dialogs) {
-        if (dialog.textContent && dialog.textContent.includes('Missing Models')) {
-          // We found a dialog to patch
-          patchAllButtons();
-          return;
-        }
-      }
-    }, 1000); // Poll every second
+      return originalClick.call(this);
+    };
+
+    console.log('[MODEL_DOWNLOADER] Browser download interception active');
   }
-  
-  // Define initialize function
+
   function initialize() {
-    // Initialize core module
-    
-    // Message handlers are now registered in model_downloader.js
-    // registerMessageHandlers() call removed
-    
-    // Patch the missing model buttons
-    patchMissingModelButtons();
-    
-    // Check if DOM is already loaded
-    if (document.readyState === 'loading') {
-      // If not, wait for it to load
-      document.addEventListener('DOMContentLoaded', () => {
-        patchMissingModelButtons();
-      });
-    } else {
-      // Run the patching immediately, but also run it again after a short delay
-      // This helps catch dialogs that might be created by scripts after page load
-      setTimeout(() => {
-        patchMissingModelButtons();
-      }, 1000);
-    }
-    
+    interceptBrowserDownloads();
     return true;
   }
 
-  // Expose functions and data to global scope
-  // First, create the core object
+  // Expose to global scope
   window.modelDownloaderCore = {
-    isTrustedDomain: isTrustedDomain,
-    downloadModelWithBackend: downloadModelWithBackend,
-    patchMissingModelButtons: patchMissingModelButtons,
-    initialize: initialize,
-    updateButtonStatus: updateButtonStatus,
-    // registerMessageHandlers removed - now in model_downloader.js
-    handleMessageEvent: handleMessageEvent,
-    checkAndCloseDialog: checkAndCloseDialog
+    isTrustedDomain, downloadModelWithBackend, interceptBrowserDownloads,
+    initialize, handleMessageEvent, getOrCreateRow, updateRow
   };
-  
-  // Make sure modelDownloader exists before assigning to it
+
   if (!window.modelDownloader) {
-    window.modelDownloader = {
-      activeDownloads: {}
-    };
+    window.modelDownloader = { activeDownloads: {} };
   }
-  
-  // Add core functions to the main modelDownloader object
   Object.assign(window.modelDownloader, window.modelDownloaderCore);
-  
-  // Message handlers are registered in model_downloader.js
-  
-  // Do NOT call initialize automatically - let backend_download.js call it
 })();

--- a/src/custom_nodes/model_downloader/js/model_downloader_core.js
+++ b/src/custom_nodes/model_downloader/js/model_downloader_core.js
@@ -158,27 +158,65 @@
     }
   }
 
-  // ── Directory guessing from DOM ──────────────────────────────────────
+  // ── Directory detection ───────────────────────────────────────────────
+  // ComfyUI folder_paths directory names that map to model types
+  const KNOWN_DIRS = [
+    'checkpoints', 'clip', 'clip_vision', 'controlnet', 'diffusion_models',
+    'embeddings', 'gligen', 'hypernetworks', 'loras', 'style_models',
+    'text_encoders', 'unet', 'upscale_models', 'vae', 'vae_approx',
+    'photomaker', 'classifiers', 'mmdets'
+  ];
+
+  // Guess the ComfyUI model directory from the download URL path segments
+  function guessDirectoryFromUrl(url) {
+    try {
+      const segments = new URL(url).pathname.toLowerCase().split('/');
+      // Walk path segments and return the first that matches a known ComfyUI directory
+      for (const seg of segments) {
+        if (KNOWN_DIRS.includes(seg)) return seg;
+      }
+      // Also check for common aliases
+      for (const seg of segments) {
+        if (seg === 'lora') return 'loras';
+        if (seg === 'embedding') return 'embeddings';
+        if (seg === 'checkpoint') return 'checkpoints';
+        if (seg === 'unet') return 'diffusion_models';
+      }
+    } catch (e) { /* ignore */ }
+    return '';
+  }
+
+  // Scan the Missing Models panel DOM for a filename → directory mapping.
+  // The panel groups models under category headers like "text_encoders (1)".
   function guessDirectoryFromDom(filename) {
-    const candidates = document.querySelectorAll('p[title]');
-    for (const el of candidates) {
-      if (el.title !== filename && !el.textContent.trim().startsWith(filename)) continue;
-      let node = el.parentElement;
-      for (let i = 0; i < 10 && node; i++) {
-        const header = node.querySelector('.text-destructive-background-hover');
-        if (header) {
-          const match = header.textContent.trim().match(/^(\S+)/);
-          if (match) return match[1];
+    // Find elements whose text content matches the filename
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let textNode;
+    while ((textNode = walker.nextNode())) {
+      const text = textNode.textContent.trim();
+      if (!text.startsWith(filename)) continue;
+      // Walk up from the matched text node to find a category header
+      // Category headers contain text like "text_encoders (2)" or "vae (1)"
+      let el = textNode.parentElement;
+      for (let i = 0; i < 20 && el; i++) {
+        // Look for sibling or parent elements with category text pattern
+        const siblings = el.parentElement?.children || [];
+        for (const sib of siblings) {
+          const sibText = sib.textContent.trim();
+          const match = sibText.match(/^(\w+)\s*\(\d+\)$/);
+          if (match && KNOWN_DIRS.includes(match[1])) {
+            return match[1];
+          }
         }
-        node = node.parentElement;
+        el = el.parentElement;
       }
     }
-    const headers = document.querySelectorAll('.text-destructive-background-hover');
-    if (headers.length === 1) {
-      const match = headers[0].textContent.trim().match(/^(\S+)/);
-      if (match) return match[1];
-    }
-    return 'checkpoints';
+    return '';
+  }
+
+  // Combined directory detection: URL first, DOM second, default last
+  function detectDirectory(url, filename) {
+    return guessDirectoryFromUrl(url) || guessDirectoryFromDom(filename) || 'checkpoints';
   }
 
   // ── WebSocket message handler ────────────────────────────────────────
@@ -302,7 +340,7 @@
       if (this.download && this.href && !this.isConnected && isTrustedDomain(this.href)) {
         const url = this.href;
         const filename = this.download || url.split('/').pop() || 'model';
-        const folder = guessDirectoryFromDom(filename);
+        const folder = detectDirectory(url, filename);
 
         console.log('[MODEL_DOWNLOADER] Intercepted browser download:', { url, filename, folder });
 

--- a/src/custom_nodes/model_downloader/js/model_downloader_core.js
+++ b/src/custom_nodes/model_downloader/js/model_downloader_core.js
@@ -195,12 +195,13 @@
 
     // Second pass: for each header, find model names in its section
     for (const header of headerElements) {
-      // Walk up to find the section container (category group)
-      let container = header.element;
-      for (let i = 0; i < 5 && container; i++) {
+      // Walk up until we find a container that holds model name elements
+      let container = header.element.parentElement;
+      while (container && container !== document.body) {
+        if (container.querySelectorAll('p[title]').length > 0) break;
         container = container.parentElement;
       }
-      if (!container) continue;
+      if (!container || container === document.body) continue;
 
       // Find all p[title] elements within this container - these have model filenames
       const modelNames = container.querySelectorAll('p[title]');
@@ -236,10 +237,8 @@
       // Look for "Missing Models" text appearing in the DOM
       if (!scanned && document.body.textContent.includes('Missing Models')) {
         scanMissingModelsPanel();
-        if (Object.keys(dirCache).length > 0) {
-          scanned = true;
-          observer.disconnect();
-        }
+        scanned = true;
+        observer.disconnect();
       }
     });
     observer.observe(document.body, { childList: true, subtree: true });

--- a/src/custom_nodes/model_downloader/js/model_downloader_core.js
+++ b/src/custom_nodes/model_downloader/js/model_downloader_core.js
@@ -149,15 +149,17 @@
     }
   }
 
+  let autoHideTimer = null;
+
   function checkAllDone() {
     if (!window.modelDownloader?.activeDownloads) return;
     const all = Object.values(window.modelDownloader.activeDownloads);
     if (all.length === 0) return;
     const done = all.every(d => d.status === 'completed' || d.status === 'error');
-    if (done) {
-      // Auto-hide panel after 8 seconds when all downloads finish
-      setTimeout(() => {
+    if (done && !autoHideTimer) {
+      autoHideTimer = setTimeout(() => {
         if (panelEl) panelEl.style.display = 'none';
+        autoHideTimer = null;
       }, 8000);
     }
   }
@@ -393,8 +395,11 @@
     } catch (error) {
       console.error('[MODEL_DOWNLOADER] Download request failed:', error.message);
       updateRow(clientDownloadId, { status: 'error', error: error.message });
-      if (window.modelDownloader.activeDownloads[clientDownloadId]) {
-        window.modelDownloader.activeDownloads[clientDownloadId].status = 'error';
+      // Entry may have been deleted after server ID mapping; update whichever exists
+      const entry = window.modelDownloader.activeDownloads[clientDownloadId] ||
+        Object.values(window.modelDownloader.activeDownloads).find(d => d.client_id === clientDownloadId);
+      if (entry) {
+        entry.status = 'error';
       }
       throw error;
     }
@@ -402,6 +407,7 @@
 
   // ── Intercept browser-initiated model downloads ──────────────────────
   function interceptBrowserDownloads() {
+    if (HTMLAnchorElement.prototype.click._mdlPatched) return;
     const originalClick = HTMLAnchorElement.prototype.click;
 
     HTMLAnchorElement.prototype.click = function() {
@@ -424,6 +430,7 @@
       }
       return originalClick.call(this);
     };
+    HTMLAnchorElement.prototype.click._mdlPatched = true;
 
     console.log('[MODEL_DOWNLOADER] Browser download interception active');
   }

--- a/src/custom_nodes/model_downloader/js/model_downloader_core.js
+++ b/src/custom_nodes/model_downloader/js/model_downloader_core.js
@@ -160,63 +160,128 @@
 
   // ── Directory detection ───────────────────────────────────────────────
   // ComfyUI folder_paths directory names that map to model types
-  const KNOWN_DIRS = [
+  const KNOWN_DIRS = new Set([
     'checkpoints', 'clip', 'clip_vision', 'controlnet', 'diffusion_models',
     'embeddings', 'gligen', 'hypernetworks', 'loras', 'style_models',
     'text_encoders', 'unet', 'upscale_models', 'vae', 'vae_approx',
     'photomaker', 'classifiers', 'mmdets'
-  ];
+  ]);
+
+  // Proactive cache: filename → directory, populated by observing the Missing Models panel
+  const dirCache = {};
+
+  // Scan the DOM for the Missing Models panel and build filename → directory mappings.
+  // The panel groups models under category headers like "loras (1)".
+  // Each model row has a <p title="filename.safetensors"> element.
+  function scanMissingModelsPanel() {
+    // Find all elements whose direct text matches "dirname (N)" pattern
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let textNode;
+    let currentDir = '';
+    const headerElements = [];
+
+    // First pass: find all category headers
+    while ((textNode = walker.nextNode())) {
+      const text = textNode.textContent.trim();
+      const match = text.match(/^(\w+)\s*\(\d+\)$/);
+      if (match && KNOWN_DIRS.has(match[1])) {
+        headerElements.push({ dir: match[1], element: textNode.parentElement });
+      }
+    }
+
+    // Second pass: for each header, find model names in its section
+    for (const header of headerElements) {
+      // Walk up to find the section container (category group)
+      let container = header.element;
+      for (let i = 0; i < 5 && container; i++) {
+        container = container.parentElement;
+      }
+      if (!container) continue;
+
+      // Find all p[title] elements within this container - these have model filenames
+      const modelNames = container.querySelectorAll('p[title]');
+      for (const p of modelNames) {
+        const name = p.getAttribute('title');
+        if (name && name.includes('.')) {
+          dirCache[name] = header.dir;
+        }
+      }
+
+      // Also check text content for filenames (backup)
+      const allText = container.textContent;
+      // Look for .safetensors, .ckpt, .pt, .bin filenames
+      const fileMatches = allText.match(/[\w\-\.]+\.(?:safetensors|ckpt|pt|bin|pth|onnx)/g);
+      if (fileMatches) {
+        for (const fname of fileMatches) {
+          if (!dirCache[fname]) {
+            dirCache[fname] = header.dir;
+          }
+        }
+      }
+    }
+
+    if (Object.keys(dirCache).length > 0) {
+      console.log('[MODEL_DOWNLOADER] Cached directory map:', { ...dirCache });
+    }
+  }
+
+  // Set up a MutationObserver to detect the Missing Models panel appearing
+  function observeMissingModelsPanel() {
+    let scanned = false;
+    const observer = new MutationObserver(() => {
+      // Look for "Missing Models" text appearing in the DOM
+      if (!scanned && document.body.textContent.includes('Missing Models')) {
+        scanMissingModelsPanel();
+        if (Object.keys(dirCache).length > 0) {
+          scanned = true;
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // Also scan periodically as fallback
+    const interval = setInterval(() => {
+      if (document.body.textContent.includes('Missing Models')) {
+        scanMissingModelsPanel();
+        if (Object.keys(dirCache).length > 0) {
+          clearInterval(interval);
+        }
+      }
+    }, 2000);
+
+    // Stop polling after 60 seconds
+    setTimeout(() => clearInterval(interval), 60000);
+  }
 
   // Guess the ComfyUI model directory from the download URL path segments
   function guessDirectoryFromUrl(url) {
     try {
       const segments = new URL(url).pathname.toLowerCase().split('/');
-      // Walk path segments and return the first that matches a known ComfyUI directory
       for (const seg of segments) {
-        if (KNOWN_DIRS.includes(seg)) return seg;
+        if (KNOWN_DIRS.has(seg)) return seg;
       }
-      // Also check for common aliases
+      // Common aliases
       for (const seg of segments) {
         if (seg === 'lora') return 'loras';
         if (seg === 'embedding') return 'embeddings';
         if (seg === 'checkpoint') return 'checkpoints';
-        if (seg === 'unet') return 'diffusion_models';
       }
     } catch (e) { /* ignore */ }
     return '';
   }
 
-  // Scan the Missing Models panel DOM for a filename → directory mapping.
-  // The panel groups models under category headers like "text_encoders (1)".
-  function guessDirectoryFromDom(filename) {
-    // Find elements whose text content matches the filename
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-    let textNode;
-    while ((textNode = walker.nextNode())) {
-      const text = textNode.textContent.trim();
-      if (!text.startsWith(filename)) continue;
-      // Walk up from the matched text node to find a category header
-      // Category headers contain text like "text_encoders (2)" or "vae (1)"
-      let el = textNode.parentElement;
-      for (let i = 0; i < 20 && el; i++) {
-        // Look for sibling or parent elements with category text pattern
-        const siblings = el.parentElement?.children || [];
-        for (const sib of siblings) {
-          const sibText = sib.textContent.trim();
-          const match = sibText.match(/^(\w+)\s*\(\d+\)$/);
-          if (match && KNOWN_DIRS.includes(match[1])) {
-            return match[1];
-          }
-        }
-        el = el.parentElement;
-      }
-    }
-    return '';
-  }
-
-  // Combined directory detection: URL first, DOM second, default last
+  // Combined directory detection: cache first, URL second, rescan DOM third, default last
   function detectDirectory(url, filename) {
-    return guessDirectoryFromUrl(url) || guessDirectoryFromDom(filename) || 'checkpoints';
+    // 1. Check proactive cache (built from Missing Models panel)
+    if (dirCache[filename]) return dirCache[filename];
+    // 2. Parse URL path for known directory names
+    const fromUrl = guessDirectoryFromUrl(url);
+    if (fromUrl) return fromUrl;
+    // 3. Try rescanning the DOM right now (panel may still be visible)
+    scanMissingModelsPanel();
+    if (dirCache[filename]) return dirCache[filename];
+    // 4. Default
+    return 'checkpoints';
   }
 
   // ── WebSocket message handler ────────────────────────────────────────
@@ -362,13 +427,15 @@
 
   function initialize() {
     interceptBrowserDownloads();
+    observeMissingModelsPanel();
     return true;
   }
 
   // Expose to global scope
   window.modelDownloaderCore = {
     isTrustedDomain, downloadModelWithBackend, interceptBrowserDownloads,
-    initialize, handleMessageEvent, getOrCreateRow, updateRow
+    initialize, handleMessageEvent, getOrCreateRow, updateRow,
+    scanMissingModelsPanel, detectDirectory, dirCache
   };
 
   if (!window.modelDownloader) {


### PR DESCRIPTION
## Summary
- Upgrade ComfyUI from v0.16.4 to v0.17.2 (3 upstream releases: assets refactor, Flux 2 KV Cache, pre-attention patches API)
- Update all vendored deps: frontend 1.41.20, workflow templates 0.9.21, Manager 4.1b2, comfy-kitchen 0.2.8, comfy-aimdo 0.2.10
- Add `blake3` Python dependency (new upstream requirement)
- Fix model downloader for ComfyUI v0.17+ frontend changes (Missing Models UI moved from modal dialog to sidebar panel with detached `<a>` element downloads)
- Fix bundled custom node symlinks not updating across Nix rebuilds (`ln -sfn` instead of conditional)

## Model Downloader Changes
The v0.17+ frontend replaced the PrimeVue modal dialog with a Vue sidebar panel that creates detached `<a>` elements for downloads. The old DOM button-patching approach no longer works.

- Replace button patching with `HTMLAnchorElement.prototype.click` interception
- Add floating progress panel (bottom-right) with per-file progress bars
- Detect correct model directory via URL path parsing + proactive DOM cache from Missing Models panel
- Move API routes from `/api/*` to `/model-downloader/*` to avoid v0.17's automatic `/api/` prefix duplication
- Re-add immediate route registration at import time (v0.17 doesn't call `setup_js_api`)

## Other Fixes
- Launcher: always refresh bundled custom node symlinks on startup (fixes stale Nix store paths after rebuilds)
- Backfill missing v0.16.4 changelog entry

## Test plan
- [x] `nix flake check` passes
- [x] `nix run .#cuda -- --base-directory ./data --listen 0.0.0.0 --use-pytorch-cross-attention --cuda-malloc --lowvram --enable-manager`
- [x] Missing models download to correct directories (vae/, text_encoders/, diffusion_models/, loras/)
- [x] Floating progress panel shows download progress with progress bars
- [x] WebSocket progress updates received and displayed