### PR TITLE
fix: skip pythonRuntimeDepsCheck for color-matcher (#51)

### DIFF
--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -672,6 +672,10 @@ lib.optionalAttrs useCuda {
       scipy
     ];
     doCheck = false;
+    # Upstream wheel's Requires-Dist lists ddt/docutils/matplotlib (docs/tests)
+    # and imageio (try/except-optional in io_handler.py) as mandatory runtime deps.
+    # Only numpy + pillow are actually required at import time.
+    dontCheckRuntimeDeps = true;
     pythonImportsCheck = [ "color_matcher" ];
   };
 }


### PR DESCRIPTION
## Summary
- Fixes #51 — `color_matcher` build failure when consumers apply this flake's overlay on top of a recent `nixpkgs` that enables `pythonRuntimeDepsCheckHook` by default.
- Sets `dontCheckRuntimeDeps = true` on the `color-matcher` override so the hook is skipped; `pythonImportsCheck = [ "color_matcher" ]` still guards that the package actually imports.

## Root cause
`color_matcher-0.6.0`'s wheel metadata declares `ddt`, `docutils`, `matplotlib`, and `imageio` as mandatory runtime deps:

```
Requires-Dist: ddt
Requires-Dist: docutils
Requires-Dist: imageio
Requires-Dist: matplotlib
Requires-Dist: numpy >=1.21
Requires-Dist: packaging >=24.2
```

None of these are actually required at import time:
- `ddt`, `docutils`, `matplotlib` — not imported anywhere in the runtime package (docs/tests only).
- `imageio` — imported inside a `try/except ImportError` in `color_matcher/io_handler.py:53,75` with a PIL fallback.

Our override only propagates `numpy`, `pillow`, `scipy`, which is what the library actually needs. Newer `nixpkgs` revisions enable `pythonRuntimeDepsCheckHook` in default hooks; it compares the wheel's `Requires-Dist` against `propagatedBuildInputs` and fails the build. Our CI doesn't trip on this because our pinned `nixpkgs` is older, but overlay consumers on a recent pin do.

Bloating the closure with `matplotlib` + Qt transitive deps to satisfy upstream's overbroad metadata would be wasteful; `dontCheckRuntimeDeps` is the nixpkgs-blessed escape hatch for exactly this case.

## Test plan
- [x] `nix flake check -L` passes: `ruff-check`, `pyright-check` (0 errors/warnings), `nixfmt`, `shellcheck`, and full `package` build all green on x86_64-linux.
- [x] `color-matcher-0.6.0` wheel builds cleanly and passes `pythonImportsCheckPhase` (`import color_matcher`).
- [ ] Consumers on the reporter's configuration (`gpuSupport = "cuda"`, newer `nixpkgs`) can now build.