### PR TITLE
feat: add Intel XPU (oneAPI / SYCL) support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,13 @@ jobs:
             platform: linux/amd64
             tag_suffix: '-rocm'
             runner: ubuntu-latest
+          - variant: xpu
+            arch: x86_64-linux
+            nix_target: dockerImageXpu
+            package_target: xpu
+            platform: linux/amd64
+            tag_suffix: '-xpu'
+            runner: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -200,7 +207,7 @@ jobs:
           sudo apt-get clean
           docker system prune -af || true
           # Extra cleanup for CUDA/ROCm builds (needs maximum disk space)
-          if [[ "${{ matrix.variant }}" =~ ^cuda$|^rocm$ ]]; then
+          if [[ "${{ matrix.variant }}" =~ ^cuda$|^rocm$|^xpu$ ]]; then
             sudo rm -rf /usr/local/share/powershell
             sudo rm -rf /usr/local/share/chromium
             sudo rm -rf /usr/local/share/vcpkg
@@ -256,7 +263,7 @@ jobs:
         run: |
           echo "Building ${{ matrix.variant }} variant for ${{ matrix.arch }}..."
           # For CUDA/ROCm builds, limit parallelism to reduce memory pressure
-          if [[ "${{ matrix.variant }}" =~ ^cuda$|^rocm$ ]]; then
+          if [[ "${{ matrix.variant }}" =~ ^cuda$|^rocm$|^xpu$ ]]; then
             nix build .#packages.${{ matrix.arch }}.${{ matrix.nix_target }} --print-build-logs --max-jobs 1 --cores 2
           else
             nix build .#packages.${{ matrix.arch }}.${{ matrix.nix_target }} --print-build-logs
@@ -302,7 +309,7 @@ jobs:
           nix build .#packages.${{ matrix.arch }}.${{ matrix.package_target }} -o result-pkg --print-build-logs
 
           # For CUDA/ROCm builds, include build-time dependencies (magma, triton, etc.)
-          if [[ "${{ matrix.variant }}" =~ ^cuda$|^rocm$ ]]; then
+          if [[ "${{ matrix.variant }}" =~ ^cuda$|^rocm$|^xpu$ ]]; then
             ./scripts/push-to-cachix.sh --build-deps ./result-pkg
           else
             ./scripts/push-to-cachix.sh ./result-pkg
@@ -428,6 +435,31 @@ jobs:
           docker buildx imagetools create --tag "$ROCM_TAG" "$ROCM_AMD64_TAG"
           docker buildx imagetools create --tag "$VERSION_ROCM_TAG" "$ROCM_AMD64_TAG"
 
+      - name: Create and push XPU manifest (x86_64 only)
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            XPU_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-xpu"
+            VERSION_XPU_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-xpu"
+            XPU_AMD64_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-xpu-amd64"
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION=${GITHUB_REF#refs/tags/v}
+            XPU_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_VERSION}-xpu"
+            VERSION_XPU_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-xpu"
+            XPU_AMD64_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_VERSION}-xpu-amd64"
+          fi
+
+          echo "Verifying XPU image exists..."
+          if ! docker manifest inspect "$XPU_AMD64_TAG" &>/dev/null; then
+            echo "ERROR: Required XPU image not found: $XPU_AMD64_TAG"
+            exit 1
+          fi
+          echo "Found: $XPU_AMD64_TAG"
+
+          # Use buildx imagetools to create tags without pulling the full image
+          echo "Creating XPU tags via registry (no local pull required)..."
+          docker buildx imagetools create --tag "$XPU_TAG" "$XPU_AMD64_TAG"
+          docker buildx imagetools create --tag "$VERSION_XPU_TAG" "$XPU_AMD64_TAG"
+
       - name: Generate manifest summary
         run: |
           echo "## Multi-Architecture Docker Images Published" >> $GITHUB_STEP_SUMMARY
@@ -446,6 +478,10 @@ jobs:
           echo "### ROCM (amd64 only)" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-rocm" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "### Intel XPU (amd64 only)" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-xpu" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   update-description:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Run with browser**: `nix run -- --open` (automatically opens browser)
 - **Run with CUDA**: `nix run .#cuda` (Linux/NVIDIA only, uses pre-built PyTorch CUDA wheels)
 - **Run with ROCm**: `nix run .#rocm` (Linux/AMD only, uses pre-built PyTorch ROCm 7.1 wheels)
+- **Run with Intel XPU**: `nix run .#xpu` (Linux/Intel only, uses pre-built PyTorch XPU wheels — oneAPI/SYCL, no IPEX)
 - **Run with custom port**: `nix run -- --port=8080`
 - **Run with network access**: `nix run -- --listen 0.0.0.0`
 - **Run with debug logging**: `nix run -- --debug` or `nix run -- --verbose`
@@ -25,11 +26,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Build Docker image**: `nix run .#buildDocker` (creates `comfy-ui:latest`)
 - **Build CUDA Docker**: `nix run .#buildDockerCuda` (creates `comfy-ui:cuda`)
 - **Build ROCm Docker**: `nix run .#buildDockerRocm` (creates `comfy-ui:rocm`)
-- **Cross-build Linux images from macOS**: `nix run .#buildDockerLinux`, `nix run .#buildDockerLinuxCuda`, `nix run .#buildDockerLinuxRocm`, `nix run .#buildDockerLinuxArm64`
-- **Pull pre-built**: `docker pull ghcr.io/utensils/comfyui-nix:latest` (or `:latest-cuda`, `:latest-rocm`)
+- **Build XPU Docker**: `nix run .#buildDockerXpu` (creates `comfy-ui:xpu`)
+- **Cross-build Linux images from macOS**: `nix run .#buildDockerLinux`, `nix run .#buildDockerLinuxCuda`, `nix run .#buildDockerLinuxRocm`, `nix run .#buildDockerLinuxXpu`, `nix run .#buildDockerLinuxArm64`
+- **Pull pre-built**: `docker pull ghcr.io/utensils/comfyui-nix:latest` (or `:latest-cuda`, `:latest-rocm`, `:latest-xpu`)
 - **Run container**: `docker run -p 8188:8188 -v $PWD/data:/data comfy-ui:latest`
 - **Run CUDA container**: `docker run --gpus all -p 8188:8188 -v $PWD/data:/data comfy-ui:cuda`
 - **Run ROCm container**: `docker run --device /dev/kfd --device /dev/dri -p 8188:8188 -v $PWD/data:/data comfy-ui:rocm`
+- **Run XPU container**: `docker run --device /dev/dri -p 8188:8188 -v $PWD/data:/data comfy-ui:xpu`
 
 ## Linting and Code Quality
 
@@ -55,7 +58,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Template input files: auto-generated in `nix/template-inputs.nix`
   - Update with: `./scripts/update-template-inputs.sh && git add nix/template-inputs.nix`
 - Python version: 3.12
-- PyTorch: macOS uses pre-built wheels (2.5.1, pinned to work around MPS bugs on macOS 26); CUDA uses pre-built wheels from pytorch.org (cu128); ROCm uses pre-built wheels from pytorch.org (rocm7.1); Linux CPU uses nixpkgs
+- PyTorch: macOS uses pre-built wheels (2.5.1, pinned to work around MPS bugs on macOS 26); CUDA uses pre-built wheels from pytorch.org (cu128); ROCm uses pre-built wheels from pytorch.org (rocm7.1); Intel XPU uses pre-built wheels from pytorch.org (xpu, oneAPI/SYCL — no IPEX); Linux CPU uses nixpkgs
 
 ## Project Architecture
 
@@ -80,11 +83,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### GPU Support Architecture
 
-The `gpuSupport` parameter is a string enum (`"none"`, `"cuda"`, `"rocm"`) that flows through the entire build:
+The `gpuSupport` parameter is a string enum (`"none"`, `"cuda"`, `"rocm"`, `"xpu"`) that flows through the entire build:
 
 `flake.nix` → `packages.nix` / `python-overrides.nix` / `docker.nix` / `apps.nix` / `modules/comfyui.nix`
 
 Each module branches on this value to select platform-specific PyTorch wheels, runtime libraries, environment variables, and launcher behavior. When adding a new GPU backend, every file in this chain needs updates.
+
+**XPU-specific notes** (Intel oneAPI / SYCL):
+
+- Wheel channel: `https://download.pytorch.org/whl/xpu` — `torch 2.10.0+xpu`, `torchvision 0.25.0+xpu`, `torchaudio 2.10.0+xpu` (cp312, Linux x86_64 only)
+- No IPEX required — ComfyUI uses `torch.xpu.is_available()` auto-detection
+- Host must provide Level Zero loader + Intel compute-runtime at runtime. The launcher prefers `/run/opengl-driver/lib` (NixOS `hardware.graphics.extraPackages`) and falls back to Nix-bundled `pkgs.level-zero` + `pkgs.intel-compute-runtime` + `pkgs.ocl-icd` for non-NixOS Linux
+- Runtime env vars set by launcher: `SYCL_CACHE_PERSISTENT=1`, `SYCL_CACHE_DIR=<data-dir>/.cache/libsycl_cache`. Opt-in: `COMFY_ENABLE_XPU_FP64_EMULATION=1` enables `OverrideDefaultFP64Settings` + `IGC_EnableDPEmulation` for iGPUs without native FP64
+- Gated on `stdenv.isLinux && stdenv.hostPlatform.isx86_64` in every module (aarch64 support does not exist upstream)
+- XPU support is untested on real hardware by maintainers — issue triage requires the reporter's hardware details (GPU model, kernel version, `clinfo`/`sycl-ls` output)
 
 ### Key Components
 
@@ -109,6 +121,8 @@ The launcher does significant work beyond just starting ComfyUI:
 - `VIRTUAL_ENV`, `PIP_TARGET` — for Manager package installs into `.venv`
 - `COMFY_VENV_PRECEDENCE` — set to `prefer-venv` to let venv packages override Nix packages (default: Nix takes precedence)
 - `LD_LIBRARY_PATH` (Linux) / `DYLD_LIBRARY_PATH` (macOS) — set automatically for system libraries
+- `SYCL_CACHE_PERSISTENT`, `SYCL_CACHE_DIR` — set on XPU builds to cache JIT kernels under `<data-dir>/.cache/libsycl_cache`
+- `COMFY_ENABLE_XPU_FP64_EMULATION` — opt-in env var (user-provided); when `=1`, launcher sets `OverrideDefaultFP64Settings=1` + `IGC_EnableDPEmulation=1` for iGPUs without native FP64
 
 **Model Downloader** (`src/custom_nodes/model_downloader/`):
 Non-blocking async download system using aiohttp with WebSocket progress updates.
@@ -142,6 +156,7 @@ fonts/         - Bundled fonts for nodes requiring system fonts
 - macOS: PyTorch pinned to 2.5.1 to work around MPS bugs on macOS 26 (Tahoe); browser opens via `/usr/bin/open`
 - CUDA: Pre-built wheels from pytorch.org with CUDA 12.8 runtime bundled (no separate toolkit needed); supports Pascal through Blackwell
 - ROCm: Pre-built wheels from pytorch.org with ROCm 7.1 runtime bundled; tested on gfx1100 (7900 XTX); `/run/opengl-driver/lib` provides AMD drivers on NixOS
+- Intel XPU: Pre-built wheels from pytorch.org (oneAPI / SYCL, no IPEX); supports Arc A/B series + Core Ultra iGPUs (Meteor Lake+); untested on maintainer hardware — treat external user reports as authoritative; `/run/opengl-driver/lib` preferred, Nix-bundled `level-zero`/`intel-compute-runtime` as non-NixOS fallback
 - Linux CPU: Uses nixpkgs PyTorch; browser opens via `xdg-open`
 - Cross-platform Docker builds work from any system via `nix run .#buildDockerLinux` etc.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ nix run github:utensils/comfyui-nix#rocm
 
 ROCm builds use pre-built PyTorch wheels from pytorch.org, so builds are fast (~2GB download); so far, GPU support has only been validated on `gfx1100`.
 
+For Intel XPU (Linux/Intel GPU):
+
+```bash
+nix run github:utensils/comfyui-nix#xpu
+```
+
+XPU builds use pre-built PyTorch wheels from pytorch.org's XPU channel (oneAPI / SYCL, no IPEX required). Officially supports Intel Arc A/B series and Core Ultra iGPUs (Meteor Lake+). Older Xe-LP iGPUs (UHD 770) are not officially supported.
+
 ## Options
 
 All [ComfyUI CLI options] are supported. Common examples:
@@ -84,6 +92,67 @@ nix run github:utensils/comfyui-nix#rocm
 ```
 
 > ROCm support contributed by [@pyqlsa](https://github.com/pyqlsa) — thank you!
+
+## Intel XPU (oneAPI / SYCL) Support
+
+Intel XPU builds are available for Linux x86_64 with Intel GPUs. The `#xpu` package uses pre-built PyTorch wheels from pytorch.org's XPU channel which:
+
+- **Fast builds**: Downloads ~2.5GB of pre-built wheels instead of compiling for hours
+- **No IPEX required**: In-tree `torch.xpu` backend is sufficient; ComfyUI auto-detects XPU
+- **Bundled runtime**: SYCL / oneAPI / MKL / TBB included in wheels
+
+### Officially supported hardware
+
+- Intel Arc A-series (Alchemist) and B-series (Battlemage) discrete GPUs
+- Core Ultra iGPUs: Meteor Lake, Arrow Lake, Lunar Lake, Panther Lake (Xe-LPG / Xe2)
+- Data Center GPU Max (Ponte Vecchio)
+
+Older Xe-LP iGPUs (UHD 770 on Alder/Raptor Lake) are **not officially supported** by Intel/PyTorch and may not work even if detected.
+
+### Host driver setup
+
+The XPU wheels bundle the SYCL runtime, but the host must provide:
+
+- Kernel driver: `i915` (Arc Alchemist) or `xe` (Battlemage, newer iGPUs)
+- Userland: Level Zero loader + Intel compute-runtime + OpenCL ICD
+
+**On NixOS** (recommended — keeps userland ICD in sync with the kernel DRM driver):
+
+```nix
+hardware.graphics = {
+  enable = true;
+  extraPackages = [
+    pkgs.intel-compute-runtime
+    pkgs.level-zero
+  ];
+};
+```
+
+The launcher prefers `/run/opengl-driver/lib` when present. On non-NixOS Linux (Ubuntu, Arch, etc.), the package bundles `level-zero` and `intel-compute-runtime` as a fallback, so `nix run .#xpu` works without additional system setup — but keep kernel drivers up to date for your GPU generation.
+
+### Running
+
+```bash
+nix run github:utensils/comfyui-nix#xpu
+```
+
+### iGPU FP64 emulation
+
+iGPUs (UHD 770, older Xe-LP) lack native FP64 hardware. If you hit `"double precision not supported"` errors, enable emulation:
+
+```bash
+COMFY_ENABLE_XPU_FP64_EMULATION=1 nix run github:utensils/comfyui-nix#xpu
+```
+
+This sets `OverrideDefaultFP64Settings=1` + `IGC_EnableDPEmulation=1`. Off by default so discrete Arc users surface real errors rather than silently emulating.
+
+### SYCL kernel cache
+
+JIT-compiled SYCL kernels are cached under `<data-directory>/.cache/libsycl_cache/` via `SYCL_CACHE_PERSISTENT=1`. First generation is slower while kernels compile; subsequent runs reuse the cache.
+
+### Status
+
+XPU support has not been tested on real Intel hardware by the project maintainers. Feedback, bug reports, and benchmarks from Intel GPU users are very welcome — please open an issue describing your hardware, kernel version, and what works / doesn't work.
 
 ## Why a Nix Flake?
 
@@ -265,6 +334,7 @@ Add ComfyUI as a package in your system configuration:
         environment.systemPackages = [ pkgs.comfy-ui ];
         # Or for CUDA: pkgs.comfy-ui-cuda
         # Or for ROCm: pkgs.comfy-ui-rocm
+        # Or for Intel XPU: pkgs.comfy-ui-xpu
       }];
     };
 
@@ -288,6 +358,7 @@ Add ComfyUI as a package in your system configuration:
     inputs.comfyui-nix.packages.${pkgs.stdenv.hostPlatform.system}.default  # CPU
     # inputs.comfyui-nix.packages.${pkgs.stdenv.hostPlatform.system}.cuda   # CUDA (Linux)
     # inputs.comfyui-nix.packages.${pkgs.stdenv.hostPlatform.system}.rocm   # ROCm (Linux)
+    # inputs.comfyui-nix.packages.${pkgs.stdenv.hostPlatform.system}.xpu    # Intel XPU (Linux)
   ];
 }
 ```
@@ -296,11 +367,12 @@ Add ComfyUI as a package in your system configuration:
 
 The overlay provides these packages:
 
-| Package              | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| `pkgs.comfy-ui`      | CPU + Apple Silicon (Metal) - use this for macOS |
-| `pkgs.comfy-ui-cuda` | NVIDIA GPUs (Linux only, all architectures)      |
-| `pkgs.comfy-ui-rocm` | AMD GPUs (Linux only, `gfx1100`)      |
+| Package              | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `pkgs.comfy-ui`      | CPU + Apple Silicon (Metal) - use this for macOS     |
+| `pkgs.comfy-ui-cuda` | NVIDIA GPUs (Linux x86_64 only, all architectures)   |
+| `pkgs.comfy-ui-rocm` | AMD GPUs (Linux x86_64 only, `gfx1100`)              |
+| `pkgs.comfy-ui-xpu`  | Intel GPUs (Linux x86_64 only, Arc + Core Ultra iGPU) |
 
 > **Note:** On macOS with Apple Silicon, the base `comfy-ui` package automatically uses Metal for GPU acceleration. No separate CUDA package is needed.
 
@@ -317,6 +389,9 @@ nix profile add github:utensils/comfyui-nix#cuda
 
 # ROCm (Linux/AMD only)
 nix profile add github:utensils/comfyui-nix#rocm
+
+# Intel XPU (Linux, Intel Arc / Core Ultra iGPU only)
+nix profile add github:utensils/comfyui-nix#xpu
 ```
 
 > **Note:** Profile installation is convenient for trying ComfyUI but isn't declarative. For reproducible setups, add the package to your NixOS/nix-darwin configuration instead.
@@ -427,6 +502,10 @@ docker run --gpus all -p 8188:8188 -v "$PWD/data:/data" ghcr.io/utensils/comfyui
 # ROCm (x86_64 only)
 # Supports `gfx1100` (and possibly others)
 docker run --gpus all -p 8188:8188 -v "$PWD/data:/data" ghcr.io/utensils/comfyui-nix:latest-rocm
+
+# Intel XPU (x86_64 only)
+# Arc A/B + Core Ultra iGPUs (Meteor Lake+). Host needs i915 or xe kernel driver.
+docker run --device /dev/dri -p 8188:8188 -v "$PWD/data:/data" ghcr.io/utensils/comfyui-nix:latest-xpu
 ```
 
 **Podman:**
@@ -440,6 +519,9 @@ podman run --device nvidia.com/gpu=all -p 8188:8188 -v "$PWD/data:/data:Z" ghcr.
 
 # ROCm
 podman run --device /dev/kfd --device /dev/dri -p 8188:8188 -v "$PWD/data:/data:rw" -v "/etc/passwd:/etc/passwd:ro" ghcr.io/utensils/comfyui-nix:latest-rocm
+
+# Intel XPU (host must have i915 or xe kernel driver + firmware)
+podman run --device /dev/dri -p 8188:8188 -v "$PWD/data:/data:Z" ghcr.io/utensils/comfyui-nix:latest-xpu
 
 ```
 
@@ -476,6 +558,7 @@ podman run \
 nix build .#dockerImage      # CPU
 nix build .#dockerImageCuda  # CUDA
 nix build .#dockerImageRocm  # ROCm
+nix build .#dockerImageXpu   # Intel XPU
 
 # Load into Docker/Podman
 docker load < result
@@ -489,6 +572,7 @@ podman load < result
 nix run .#buildDocker      # CPU
 nix run .#buildDockerCuda  # CUDA
 nix run .#buildDockerRocm  # ROCm
+nix run .#buildDockerXpu   # Intel XPU
 ```
 
 **Note:** Docker/Podman on macOS runs CPU-only. For GPU acceleration on Apple Silicon, use `nix run` directly.

--- a/flake.nix
+++ b/flake.nix
@@ -131,12 +131,15 @@
           # Docker CUDA images use pre-built wheels (all architectures supported)
           linuxX86PackagesCuda = mkComfyPackages pkgsLinuxX86 { gpuSupport = "cuda"; };
           linuxX86PackagesRocm = mkComfyPackages pkgsLinuxX86 { gpuSupport = "rocm"; };
+          # Intel XPU (oneAPI / SYCL) — Linux x86_64 only
+          linuxX86PackagesXpu = mkComfyPackages pkgsLinuxX86 { gpuSupport = "xpu"; };
           linuxArm64Packages = mkComfyPackages pkgsLinuxArm64 { };
 
           nativePackages = mkComfyPackages pkgs { };
           # CUDA uses pre-built wheels (supports all GPU architectures)
           nativePackagesCuda = mkComfyPackages pkgs { gpuSupport = "cuda"; };
           nativePackagesRocm = mkComfyPackages pkgs { gpuSupport = "rocm"; };
+          nativePackagesXpu = mkComfyPackages pkgs { gpuSupport = "xpu"; };
 
           pythonEnv = mkPythonEnv pkgs;
 
@@ -189,6 +192,7 @@
             dockerImageLinux = linuxX86Packages.dockerImage;
             dockerImageLinuxCuda = linuxX86PackagesCuda.dockerImageCuda;
             dockerImageLinuxRocm = linuxX86PackagesRocm.dockerImageRocm;
+            dockerImageLinuxXpu = linuxX86PackagesXpu.dockerImageXpu;
             dockerImageLinuxArm64 = linuxArm64Packages.dockerImage;
           }
           // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
@@ -200,6 +204,10 @@
             dockerImageCuda = nativePackagesCuda.dockerImageCuda;
             rocm = nativePackagesRocm.default;
             dockerImageRocm = nativePackagesRocm.dockerImageRocm;
+            # Intel XPU (oneAPI / SYCL) — pre-built wheels, Linux x86_64 only.
+            # Targets Arc A/B series and Core Ultra iGPUs (Meteor Lake+).
+            xpu = nativePackagesXpu.default;
+            dockerImageXpu = nativePackagesXpu.dockerImageXpu;
           };
 
           # Expose custom nodes for direct use
@@ -289,6 +297,12 @@
               self.packages.${final.stdenv.hostPlatform.system}.rocm
             else
               throw "comfy-ui-rocm is only available on x86_64 Linux";
+          # Intel XPU variant (x86_64 Linux only) - pre-built wheels from pytorch.org/whl/xpu
+          comfy-ui-xpu =
+            if final.stdenv.isLinux && final.stdenv.isx86_64 then
+              self.packages.${final.stdenv.hostPlatform.system}.xpu
+            else
+              throw "comfy-ui-xpu is only available on x86_64 Linux";
           # Add custom nodes to overlay
           comfyui-custom-nodes = self.legacyPackages.${final.stdenv.hostPlatform.system}.customNodes;
         };

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -127,6 +127,15 @@ in
     };
   };
 }
+// pkgs.lib.optionalAttrs (packages ? xpu) {
+  xpu = {
+    type = "app";
+    program = "${packages.xpu}/bin/comfy-ui";
+    meta = {
+      description = "Run ComfyUI with Intel XPU (oneAPI / SYCL)";
+    };
+  };
+}
 // pkgs.lib.optionalAttrs (packages ? dockerImage) {
   buildDocker = mkApp "build-docker" "Build ComfyUI Docker image (CPU)" ''
     echo "Building Docker image for ComfyUI..."
@@ -151,6 +160,16 @@ in
     docker load < ${packages.dockerImageRocm}
     echo "ROCm-enabled Docker image built successfully! You can now run it with:"
     echo "docker run --gpus all -p 8188:8188 -v \$PWD/data:/data comfy-ui:rocm"
+  '' [ pkgs.docker ];
+}
+// pkgs.lib.optionalAttrs (packages ? dockerImageXpu) {
+  buildDockerXpu = mkApp "build-docker-xpu" "Build ComfyUI Docker image with Intel XPU support" ''
+    echo "Building Docker image for ComfyUI with Intel XPU (oneAPI) support..."
+    docker load < ${packages.dockerImageXpu}
+    echo "XPU-enabled Docker image built successfully! You can now run it with:"
+    echo "docker run --device /dev/dri -p 8188:8188 -v \$PWD/data:/data comfy-ui:xpu"
+    echo ""
+    echo "Note: Host kernel must have i915 or xe driver + matching firmware for the GPU."
   '' [ pkgs.docker ];
 }
 # Cross-platform Docker build apps (always available, use remote builder on non-Linux)
@@ -186,6 +205,20 @@ in
         docker load < ${packages.dockerImageLinuxRocm}
         echo "ROCm-enabled Docker image built successfully! You can now run it with:"
         echo "docker run --gpus all -p 8188:8188 -v \$PWD/data:/data comfy-ui:rocm"
+      ''
+      [ pkgs.docker ];
+}
+// pkgs.lib.optionalAttrs (packages ? dockerImageLinuxXpu) {
+  buildDockerLinuxXpu =
+    mkApp "build-docker-linux-xpu" "Build ComfyUI Docker image for Linux x86_64 with Intel XPU"
+      ''
+        echo "Building Linux x86_64 Docker image for ComfyUI with Intel XPU support..."
+        echo "Note: Uses remote builder if running on non-Linux system"
+        docker load < ${packages.dockerImageLinuxXpu}
+        echo "XPU-enabled Docker image built successfully! You can now run it with:"
+        echo "docker run --device /dev/dri -p 8188:8188 -v \$PWD/data:/data comfy-ui:xpu"
+        echo ""
+        echo "Note: Host kernel must have i915 or xe driver + matching firmware."
       ''
       [ pkgs.docker ];
 }

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -6,6 +6,16 @@
 }:
 {
   package = packages.default;
+}
+# XPU build-only check (Linux x86_64 only).
+# The project maintainer has no Intel GPU, so runtime testing relies on external
+# contributors. This check at least verifies the wheel patching and closure build
+# succeed, catching the most common regression class (missing runtime libs,
+# broken overlay, upstream wheel metadata changes).
+// pkgs.lib.optionalAttrs (packages ? xpu) {
+  package-xpu = packages.xpu;
+}
+// {
 
   pytest =
     let

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -9,13 +9,14 @@
       name,
       tag,
       comfyUiPackage,
-      gpuSupport ? "none", # "none", "cuda", "rocm"
+      gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
       cudaVersion ? "cu128",
       extraLabels ? { },
     }:
     let
       useCuda = gpuSupport == "cuda";
       useRocm = gpuSupport == "rocm";
+      useXpu = gpuSupport == "xpu";
       useCpu = gpuSupport == "none";
       baseEnv = [
         "HOME=/root"
@@ -30,21 +31,32 @@
         "NVIDIA_VISIBLE_DEVICES=all"
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility"
       ];
+      # Intel compute-runtime ICD is registered via OCL_ICD_VENDORS so that
+      # ocl-icd (via /etc/OpenCL/vendors) can find it inside the container.
+      xpuEnv = lib.optionals useXpu [
+        "OCL_ICD_VENDORS=${pkgs.intel-compute-runtime}/etc/OpenCL/vendors"
+      ];
+      titleSuffix =
+        if useCuda then
+          " CUDA"
+        else if useRocm then
+          " ROCm"
+        else if useXpu then
+          " XPU"
+        else
+          "";
+      descSuffix =
+        if useCuda then
+          " with CUDA support for GPU acceleration"
+        else if useRocm then
+          " with ROCm support for GPU acceleration"
+        else if useXpu then
+          " with Intel XPU support (oneAPI / SYCL) for GPU acceleration"
+        else
+          " - The most powerful and modular diffusion model GUI";
       labels = {
-        "org.opencontainers.image.title" =
-          if useCuda then
-            "ComfyUI CUDA"
-          else if useRocm then
-            "ComfyUI ROCm"
-          else
-            "ComfyUI";
-        "org.opencontainers.image.description" =
-          if useCuda then
-            "ComfyUI with CUDA support for GPU acceleration"
-          else if useRocm then
-            "ComfyUI with ROCm support for GPU acceleration"
-          else
-            "ComfyUI - The most powerful and modular diffusion model GUI";
+        "org.opencontainers.image.title" = "ComfyUI" + titleSuffix;
+        "org.opencontainers.image.description" = "ComfyUI" + descSuffix;
         "org.opencontainers.image.source" = "https://github.com/utensils/comfyui-nix";
         "org.opencontainers.image.licenses" = "GPL-3.0";
       }
@@ -73,6 +85,14 @@
         ++ lib.optionals useRocm [
           # rocminfo suppresses a ComfyUI startup warning about missing AMD GPU info
           pkgs.rocmPackages.rocminfo
+        ]
+        ++ lib.optionals useXpu [
+          # XPU userland: Level Zero loader, Intel compute-runtime (OpenCL ICD
+          # + Level Zero driver). Users still must pass `--device /dev/dri` and
+          # have a compatible i915/xe kernel driver on the host.
+          pkgs.level-zero
+          pkgs.intel-compute-runtime
+          pkgs.ocl-icd
         ];
         pathsToLink = [
           "/bin"
@@ -89,7 +109,7 @@
           "0.0.0.0"
         ]
         ++ lib.optionals useCpu [ "--cpu" ];
-        Env = baseEnv ++ cudaEnv;
+        Env = baseEnv ++ cudaEnv ++ xpuEnv;
         ExposedPorts = {
           "8188/tcp" = { };
         };

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -9,6 +9,7 @@ let
 
   useCuda = cfg.gpuSupport == "cuda";
   useRocm = cfg.gpuSupport == "rocm";
+  useXpu = cfg.gpuSupport == "xpu";
   useCpu = cfg.gpuSupport == "none";
 
   # Determine which package to use based on configuration
@@ -18,6 +19,8 @@ let
       pkgs.comfy-ui-cuda
     else if useRocm then
       pkgs.comfy-ui-rocm
+    else if useXpu then
+      pkgs.comfy-ui-xpu
     else
       pkgs.comfy-ui;
   args = [
@@ -82,6 +85,7 @@ in
       type = lib.types.enum [
         "cuda"
         "rocm"
+        "xpu"
         "none"
       ];
       default = "none";
@@ -103,9 +107,28 @@ in
         Select ROCm support for AMD GPUs. This is recommended for most users
         with AMD graphics cards as it provides significant performance improvements.
 
-        When selected, uses pre-built PyTorch ROCm wheels based on 7.1. Using 
+        When selected, uses pre-built PyTorch ROCm wheels based on 7.1. Using
         this configuration, `gfx1100` has been tested as working, but others
         may also work. Requires AMD drivers to be installed on the system.
+
+        ---
+
+        Select `xpu` for Intel GPUs (oneAPI / SYCL, no IPEX required). Targets
+        Intel Arc A/B series discrete GPUs and Core Ultra iGPUs (Meteor Lake+).
+        Older Xe-LP iGPUs (UHD 770) are not officially supported.
+
+        When selected, you must also configure Intel driver stack on the host,
+        typically via `hardware.graphics`:
+
+        ```
+        hardware.graphics = {
+          enable = true;
+          extraPackages = [ pkgs.intel-compute-runtime pkgs.level-zero ];
+        };
+        ```
+
+        Not yet validated on real Intel hardware by the project maintainers —
+        feedback welcome.
       '';
     };
 
@@ -154,12 +177,16 @@ in
       type = lib.types.package;
       default = resolvePackage;
       defaultText = lib.literalExpression ''
-        if useCuda then pkgs.comfy-ui-cuda else if useRocm then pkgs.comfy-ui-rocm else pkgs.comfy-ui
+        if useCuda then pkgs.comfy-ui-cuda
+        else if useRocm then pkgs.comfy-ui-rocm
+        else if useXpu then pkgs.comfy-ui-xpu
+        else pkgs.comfy-ui
       '';
       description = ''
-        ComfyUI package to run. Automatically set based on CUDA/ROCm configuration:
+        ComfyUI package to run. Automatically set based on `gpuSupport`:
         - `gpuSupport = "cuda"`: CUDA package (supports all GPU architectures)
         - `gpuSupport = "rocm"`: ROCm package (`gfx1100` tested)
+        - `gpuSupport = "xpu"`: Intel XPU package (oneAPI / SYCL; Arc + Core Ultra iGPU)
         - Otherwise: CPU-only build
 
         Can be overridden for fully custom builds.
@@ -300,10 +327,15 @@ in
       wants = [ "network-online.target" ];
       requires = cfg.requiresMounts;
       wantedBy = [ "multi-user.target" ];
-      path = lib.optionals useRocm [
-        # rocminfo suppresses a ComfyUI startup warning about missing AMD GPU info
-        pkgs.rocmPackages.rocminfo
-      ];
+      path =
+        lib.optionals useRocm [
+          # rocminfo suppresses a ComfyUI startup warning about missing AMD GPU info
+          pkgs.rocmPackages.rocminfo
+        ]
+        ++ lib.optionals useXpu [
+          # clinfo helps users diagnose Intel GPU visibility from the service env
+          pkgs.clinfo
+        ];
 
       # Symlink declarative custom nodes before starting
       preStart = customNodesPreStart;

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -3,11 +3,23 @@
   lib,
   versions,
   pythonOverrides,
-  gpuSupport ? "none", # "none", "cuda", "rocm"
+  gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
 }:
 let
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
   useRocm = gpuSupport == "rocm" && pkgs.stdenv.isLinux;
+  useXpu = gpuSupport == "xpu" && pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64;
+
+  # Intel XPU runtime libraries (Level Zero loader, Intel compute-runtime, OpenCL ICD)
+  # Bundled as a fallback when /run/opengl-driver/lib isn't available (non-NixOS Linux,
+  # Docker images without host driver pass-through). On NixOS, the launcher prefers
+  # system-provided libs via /run/opengl-driver/lib (populated by hardware.graphics.extraPackages)
+  # to keep the userland ICD in sync with the kernel DRM driver.
+  xpuRuntimeLibs = lib.optionals useXpu [
+    pkgs.level-zero
+    pkgs.intel-compute-runtime
+    pkgs.ocl-icd
+  ];
 
   python = pkgs.python312.override { packageOverrides = pythonOverrides; };
 
@@ -234,27 +246,32 @@ let
 
   # NOTE: Some custom nodes (and some Python wheels) dlopen GUI-related libs at runtime
   # (e.g. OpenCV highgui / Qt platform plugins). Ensure common X11 libs are discoverable.
-  libPath = lib.makeLibraryPath [
-    pkgs.stdenv.cc.cc.lib
-    pkgs.glib
-    pkgs.libGL
-    # X11 / XCB runtime libs (fixes: libxcb.so.1 not found)
-    pkgs.xorg.libxcb
-    pkgs.xorg.libX11
-    pkgs.xorg.libXext
-    pkgs.xorg.libXrender
-    pkgs.xorg.libXfixes
-    pkgs.xorg.libXi
-    pkgs.xorg.libXrandr
-    pkgs.xorg.libXcursor
-    pkgs.xorg.libXcomposite
-    pkgs.xorg.libXdamage
-    pkgs.xorg.libXau
-    pkgs.xorg.libXdmcp
-    pkgs.xorg.libSM
-    pkgs.xorg.libICE
-    pkgs.libxkbcommon
-  ];
+  libPath = lib.makeLibraryPath (
+    [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.glib
+      pkgs.libGL
+      # X11 / XCB runtime libs (fixes: libxcb.so.1 not found)
+      pkgs.xorg.libxcb
+      pkgs.xorg.libX11
+      pkgs.xorg.libXext
+      pkgs.xorg.libXrender
+      pkgs.xorg.libXfixes
+      pkgs.xorg.libXi
+      pkgs.xorg.libXrandr
+      pkgs.xorg.libXcursor
+      pkgs.xorg.libXcomposite
+      pkgs.xorg.libXdamage
+      pkgs.xorg.libXau
+      pkgs.xorg.libXdmcp
+      pkgs.xorg.libSM
+      pkgs.xorg.libICE
+      pkgs.libxkbcommon
+    ]
+    # XPU runtime libs (Level Zero, Intel compute-runtime, OpenCL ICD) — fallback
+    # when /run/opengl-driver/lib isn't available. Launcher prefers system libs.
+    ++ xpuRuntimeLibs
+  );
 
   # Platform-specific default data directory
   # macOS: ~/Library/Application Support/comfy-ui (Apple convention)
@@ -275,9 +292,11 @@ let
     else
       ''
         # Linux: Set LD_LIBRARY_PATH for dynamic libraries
+        # Order matters: system driver libs (/run/opengl-driver/lib on NixOS) take
+        # precedence over Nix-bundled libs so userland ICDs stay in sync with the
+        # kernel DRM driver. This covers NVIDIA (CUDA), AMD (ROCm), and Intel (XPU).
         export LD_LIBRARY_PATH="${libPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-        # Add NVIDIA driver libraries if available (NixOS)
         if [[ -d "/run/opengl-driver/lib" ]]; then
           export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
         fi
@@ -552,6 +571,26 @@ let
             export FACEXLIB_MODELPATH="$BASE_DIR/.cache/facexlib"
             mkdir -p "$FACEXLIB_MODELPATH/facexlib/weights"
 
+      ${lib.optionalString useXpu ''
+        # =====================================================================
+        # Intel XPU (oneAPI / SYCL) runtime setup
+        # =====================================================================
+        # Cache SYCL JIT kernels across runs (big startup win — default is off).
+        # Redirected into the data directory to keep it under user control.
+        export SYCL_CACHE_PERSISTENT=1
+        export SYCL_CACHE_DIR="$BASE_DIR/.cache/libsycl_cache"
+        mkdir -p "$SYCL_CACHE_DIR"
+
+        # Opt-in FP64 emulation for iGPUs without native double-precision hardware
+        # (UHD 770, older Xe-LP). Off by default so discrete Arc surfaces real
+        # errors instead of silently emulating. Users hitting "double precision
+        # not supported" can export COMFY_ENABLE_XPU_FP64_EMULATION=1 before launch.
+        if [[ "''${COMFY_ENABLE_XPU_FP64_EMULATION:-0}" == "1" ]]; then
+          export OverrideDefaultFP64Settings=1
+          export IGC_EnableDPEmulation=1
+        fi
+      ''}
+
             # Open browser if requested (background, after short delay)
             if [[ "$OPEN_BROWSER" == "true" ]]; then
               (sleep 3 && ${browserCommand} "http://127.0.0.1:$PORT" 2>/dev/null) &
@@ -664,6 +703,16 @@ let
       "org.opencontainers.image.version" = versions.comfyui.version;
     };
   };
+
+  dockerImageXpu = dockerLib.mkDockerImage {
+    inherit gpuSupport;
+    name = "comfy-ui";
+    tag = "xpu";
+    comfyUiPackage = comfyUiPackage;
+    extraLabels = {
+      "org.opencontainers.image.version" = versions.comfyui.version;
+    };
+  };
 in
 {
   default = comfyUiPackage;
@@ -671,6 +720,7 @@ in
     dockerImage
     dockerImageCuda
     dockerImageRocm
+    dockerImageXpu
     pythonRuntime
     comfyuiSrc
     modelDownloaderDir

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -1,12 +1,14 @@
 {
   pkgs,
   versions,
-  gpuSupport ? "none", # "none", "cuda", "rocm"
+  gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
 }:
 let
   lib = pkgs.lib;
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
   useRocm = gpuSupport == "rocm" && pkgs.stdenv.isLinux;
+  # Intel XPU wheels are Linux x86_64 only (no aarch64 upstream)
+  useXpu = gpuSupport == "xpu" && pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64;
   useDarwinArm64 = pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64;
   sentencepieceNoGperf = pkgs.sentencepiece.override { withGPerfTools = false; };
 
@@ -18,6 +20,41 @@ let
   # Pre-built PyTorch ROCm wheels from pytorch.org
   # These avoid compiling PyTorch from source (which requires 30-60GB RAM and hours of build time)
   rocmWheels = versions.pytorchWheels.rocm71;
+
+  # Pre-built PyTorch XPU wheels from pytorch.org (Intel oneAPI / SYCL)
+  # Unlike CUDA/ROCm, the XPU torch wheel does NOT bundle its SYCL / MKL /
+  # Intel compiler runtimes — they ship as ~20 separate PyPI wheels declared
+  # in Requires-Dist. All pinned in versions.xpuRuntime and packaged below.
+  # Host still provides Level Zero loader + Intel compute-runtime at runtime.
+  xpuWheels = versions.pytorchWheels.xpu;
+
+  # Ignore-list for deps neither the wheels nor nixpkgs provide.
+  # Intel wheel-to-wheel SONAME refs are resolved via cross-wheel buildInputs
+  # in the mkIntelRuntime helper below — NOT via this ignore list.
+  xpuIgnoreMissingLibs = [
+    # Host-provided (Level Zero loader + Intel compute-runtime, on NixOS via
+    # hardware.graphics.extraPackages, on other distros via system packaging)
+    "libze_loader.so.1"
+    "libze_intel_gpu.so.1"
+    "libOpenCL.so.1"
+    "libigdrcl.so"
+    "libigc.so.2"
+    # impi-rt fabric plugins (RDMA / InfiniBand / PSM / EFA / UCX) — loaded
+    # only when MPI distributed mode is requested. ComfyUI is single-node, so
+    # these fabric adapters are never opened and can safely be absent.
+    "librdmacm.so.1"
+    "libibverbs.so.1"
+    "libucp.so.0"
+    "libucs.so.0"
+    "libuct.so.0"
+    "libnuma.so.1"
+    "libpsm2.so.2"
+    "libefa.so.1"
+    "libfabric.so.1"
+    "libnl-3.so.200"
+    "libnl-route-3.so.200"
+    "libze_loader.so" # versionless alias
+  ];
 
   # Pre-built PyTorch wheels for macOS Apple Silicon
   # PyTorch 2.5.1 is used instead of 2.9.x due to MPS bugs on macOS 26 (Tahoe)
@@ -480,6 +517,217 @@ lib.optionalAttrs useCuda {
     };
   };
 }
+# Intel XPU torch + runtime wheels
+# The XPU torch wheel only contains torch-proper binaries (~240 MB). Its Intel
+# runtime dependencies (SYCL, MKL, oneCCL, Intel compiler RT, TBB, PTI, triton)
+# ship as ~20 separate wheels pinned in versions.xpuRuntime. Each is built as
+# its own Python package below via mkIntelRuntime, then all are propagated as
+# torch's deps so auto-patchelf can resolve libtorch_xpu.so's sibling SONAMEs.
+// lib.optionalAttrs useXpu (
+  let
+    # The Intel runtime wheels contain no Python code — just .so files under
+    # the wheel's `.data/data/lib/` convention. Rather than 22 individual
+    # buildPythonPackage derivations (which cross-reference each other and
+    # trigger infinite recursion through requiredPythonModules), fetch and
+    # unpack each wheel into a single combined derivation. All cross-wheel
+    # SONAMEs resolve against this unified lib/ dir, and it's one buildInput
+    # for torch instead of 22.
+    intelOneapiRuntime = pkgs.stdenv.mkDerivation {
+      pname = "intel-oneapi-runtime";
+      version = "2025.3";
+      srcs = lib.mapAttrsToList (_: spec: pkgs.fetchurl { inherit (spec) url hash; }) versions.xpuRuntime;
+      dontConfigure = true;
+      dontBuild = true;
+      sourceRoot = ".";
+      nativeBuildInputs = [
+        pkgs.unzip
+        pkgs.autoPatchelfHook
+      ];
+      buildInputs = wheelBuildInputs;
+      autoPatchelfIgnoreMissingDeps = xpuIgnoreMissingLibs;
+      unpackPhase = ''
+        runHook preUnpack
+        for whl in $srcs; do
+          mkdir -p "wheel_$(basename "$whl" .whl)"
+          unzip -q "$whl" -d "wheel_$(basename "$whl" .whl)"
+        done
+        runHook postUnpack
+      '';
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/lib $out/share/intel-oneapi
+        # Collect .so files from each wheel's .data/data/lib into $out/lib.
+        # Later wheels' files overwrite earlier only on exact filename match;
+        # Intel wheels use distinct filenames so this is safe.
+        for wheel_dir in wheel_*; do
+          if [ -d "$wheel_dir" ]; then
+            for data_lib in "$wheel_dir"/*.data/data/lib; do
+              if [ -d "$data_lib" ]; then
+                cp -rn "$data_lib"/. $out/lib/ 2>/dev/null || \
+                  cp -r "$data_lib"/. $out/lib/
+              fi
+            done
+            # Also copy any top-level lib dirs (some wheels use that layout)
+            if [ -d "$wheel_dir/lib" ]; then
+              cp -rn "$wheel_dir/lib"/. $out/lib/ 2>/dev/null || true
+            fi
+            # Preserve license / manifest files under share/ for compliance
+            for meta in "$wheel_dir"/*.dist-info/METADATA; do
+              if [ -f "$meta" ]; then
+                pname=$(basename "$(dirname "$meta")" .dist-info)
+                mkdir -p "$out/share/intel-oneapi/$pname"
+                cp "$meta" "$out/share/intel-oneapi/$pname/"
+              fi
+            done
+          fi
+        done
+        runHook postInstall
+      '';
+      # Runtime library stuff — no binaries, no Python, just .so files.
+      dontStrip = true;
+      meta = {
+        description = "Combined Intel oneAPI runtime libraries (from PyPI wheels)";
+        homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html";
+        license = lib.licenses.unfreeRedistributable;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+  in
+  {
+    torch = final.buildPythonPackage {
+      pname = "torch";
+      version = xpuWheels.torch.version;
+      format = "wheel";
+      src = pkgs.fetchurl {
+        url = xpuWheels.torch.url;
+        hash = xpuWheels.torch.hash;
+      };
+      dontBuild = true;
+      dontConfigure = true;
+      nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+      # Combined Intel oneAPI runtime derivation provides all SYCL/MKL/oneCCL/
+      # Intel compiler RT / TBB / PTI .so files. Listed in buildInputs so
+      # auto-patchelf adds its lib/ to torch's RPATH and resolves sibling
+      # SONAMEs (libsycl.so.8, libmkl_sycl_*.so.5, libccl.so.1, etc).
+      buildInputs = wheelBuildInputs ++ [ intelOneapiRuntime ];
+      autoPatchelfIgnoreMissingDeps = xpuIgnoreMissingLibs;
+      # Intel oneAPI runtime is propagated so its lib/ is on LD_LIBRARY_PATH
+      # at ComfyUI runtime (the launcher also sets this explicitly).
+      propagatedBuildInputs = with final; [
+        filelock
+        typing-extensions
+        sympy
+        networkx
+        jinja2
+        fsspec
+      ];
+      propagatedNativeBuildInputs = [ intelOneapiRuntime ];
+      pythonImportsCheck = [ ];
+      doCheck = false;
+      dontCheckRuntimeDeps = true; # Intel wheel pip names use hyphens/underscores inconsistently
+
+      passthru = {
+        cudaSupport = false;
+        rocmSupport = false;
+        xpuSupport = true;
+        cudaPackages = { };
+      };
+
+      meta = {
+        description = "PyTorch with Intel XPU ${xpuWheels.torch.version} (pre-built wheel, oneAPI/SYCL)";
+        homepage = "https://pytorch.org";
+        license = lib.licenses.bsd3;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+
+    torchvision = final.buildPythonPackage {
+      pname = "torchvision";
+      version = xpuWheels.torchvision.version;
+      format = "wheel";
+      src = pkgs.fetchurl {
+        url = xpuWheels.torchvision.url;
+        hash = xpuWheels.torchvision.hash;
+      };
+      dontBuild = true;
+      dontConfigure = true;
+      nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+      buildInputs = wheelBuildInputs ++ [ final.torch ];
+      # torch libs are loaded via Python import, not dlopen
+      autoPatchelfIgnoreMissingDeps = [
+        "libc10.so"
+        "libc10_xpu.so"
+        "libtorch.so"
+        "libtorch_cpu.so"
+        "libtorch_xpu.so"
+        "libtorch_python.so"
+      ];
+      propagatedBuildInputs = with final; [
+        torch
+        numpy
+        pillow
+      ];
+      pythonImportsCheck = [ ];
+      doCheck = false;
+      meta = {
+        description = "TorchVision with Intel XPU (pre-built wheel)";
+        homepage = "https://pytorch.org/vision";
+        license = lib.licenses.bsd3;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+
+    torchaudio = final.buildPythonPackage {
+      pname = "torchaudio";
+      version = xpuWheels.torchaudio.version;
+      format = "wheel";
+      src = pkgs.fetchurl {
+        url = xpuWheels.torchaudio.url;
+        hash = xpuWheels.torchaudio.hash;
+      };
+      dontBuild = true;
+      dontConfigure = true;
+      nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+      buildInputs = wheelBuildInputs ++ [ final.torch ];
+      autoPatchelfIgnoreMissingDeps = [
+        "libc10.so"
+        "libc10_xpu.so"
+        "libtorch.so"
+        "libtorch_cpu.so"
+        "libtorch_xpu.so"
+        "libtorch_python.so"
+        "libsox.so"
+        # FFmpeg 4.x/5.x/6.x — same as ROCm torchaudio (wheel bundles multiple backends)
+        "libavutil.so.56"
+        "libavcodec.so.58"
+        "libavformat.so.58"
+        "libavfilter.so.7"
+        "libavdevice.so.58"
+        "libavutil.so.57"
+        "libavcodec.so.59"
+        "libavformat.so.59"
+        "libavfilter.so.8"
+        "libavdevice.so.59"
+        "libavutil.so.58"
+        "libavcodec.so.60"
+        "libavformat.so.60"
+        "libavfilter.so.9"
+        "libavdevice.so.60"
+      ];
+      propagatedBuildInputs = with final; [
+        torch
+      ];
+      pythonImportsCheck = [ ];
+      doCheck = false;
+      meta = {
+        description = "TorchAudio with Intel XPU (pre-built wheel)";
+        homepage = "https://pytorch.org/audio";
+        license = lib.licenses.bsd2;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+  }
+)
 # Spandrel and other packages that need explicit torch handling
 // lib.optionalAttrs (prev ? torch) {
   spandrel = final.buildPythonPackage rec {
@@ -604,7 +852,7 @@ lib.optionalAttrs useCuda {
 }
 
 # Disable accelerate test that fails with torch 2.10.0 inductor in Nix sandbox
-// lib.optionalAttrs ((useCuda || useRocm) && (prev ? accelerate)) {
+// lib.optionalAttrs ((useCuda || useRocm || useXpu) && (prev ? accelerate)) {
   accelerate = prev.accelerate.overridePythonAttrs (old: {
     disabledTests = (old.disabledTests or [ ]) ++ [ "test_convert_to_fp32" ];
   });

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -525,17 +525,48 @@ lib.optionalAttrs useCuda {
 # torch's deps so auto-patchelf can resolve libtorch_xpu.so's sibling SONAMEs.
 // lib.optionalAttrs useXpu (
   let
-    # The Intel runtime wheels contain no Python code — just .so files under
-    # the wheel's `.data/data/lib/` convention. Rather than 22 individual
+    # triton-xpu ships a real Python `triton/` top-level module (not just .so
+    # files under .data/data/lib), so it needs its own buildPythonPackage for
+    # Python to import it. Without this, torch.compile / Inductor falls back
+    # to nixpkgs' non-XPU triton or fails at dynamo compile time.
+    tritonXpu = final.buildPythonPackage {
+      pname = "triton";
+      version = versions.xpuRuntime.triton-xpu.version;
+      format = "wheel";
+      src = pkgs.fetchurl {
+        url = versions.xpuRuntime.triton-xpu.url;
+        hash = versions.xpuRuntime.triton-xpu.hash;
+      };
+      dontBuild = true;
+      dontConfigure = true;
+      nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+      buildInputs = wheelBuildInputs;
+      autoPatchelfIgnoreMissingDeps = xpuIgnoreMissingLibs;
+      propagatedBuildInputs = with final; [ filelock ];
+      pythonImportsCheck = [ ]; # needs XPU runtime; can't import in build sandbox
+      doCheck = false;
+      dontCheckRuntimeDeps = true;
+      meta = {
+        description = "Triton compiler with Intel XPU backend";
+        homepage = "https://github.com/intel/intel-xpu-backend-for-triton";
+        license = lib.licenses.mit;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+
+    # The other Intel runtime wheels contain no Python code — just .so files
+    # under the wheel's `.data/data/lib/` convention. Rather than 21 individual
     # buildPythonPackage derivations (which cross-reference each other and
     # trigger infinite recursion through requiredPythonModules), fetch and
     # unpack each wheel into a single combined derivation. All cross-wheel
     # SONAMEs resolve against this unified lib/ dir, and it's one buildInput
-    # for torch instead of 22.
+    # for torch instead of 21. triton-xpu is excluded — see tritonXpu above.
     intelOneapiRuntime = pkgs.stdenv.mkDerivation {
       pname = "intel-oneapi-runtime";
       version = "2025.3";
-      srcs = lib.mapAttrsToList (_: spec: pkgs.fetchurl { inherit (spec) url hash; }) versions.xpuRuntime;
+      srcs = lib.mapAttrsToList (_: spec: pkgs.fetchurl { inherit (spec) url hash; }) (
+        lib.filterAttrs (n: _: n != "triton-xpu") versions.xpuRuntime
+      );
       dontConfigure = true;
       dontBuild = true;
       sourceRoot = ".";
@@ -594,6 +625,9 @@ lib.optionalAttrs useCuda {
     };
   in
   {
+    # Expose triton as a named attr so python.withPackages can pick it up.
+    triton = tritonXpu;
+
     torch = final.buildPythonPackage {
       pname = "torch";
       version = xpuWheels.torch.version;
@@ -612,15 +646,18 @@ lib.optionalAttrs useCuda {
       buildInputs = wheelBuildInputs ++ [ intelOneapiRuntime ];
       autoPatchelfIgnoreMissingDeps = xpuIgnoreMissingLibs;
       # Intel oneAPI runtime is propagated so its lib/ is on LD_LIBRARY_PATH
-      # at ComfyUI runtime (the launcher also sets this explicitly).
-      propagatedBuildInputs = with final; [
-        filelock
-        typing-extensions
-        sympy
-        networkx
-        jinja2
-        fsspec
-      ];
+      # at ComfyUI runtime (the launcher also sets this explicitly). triton
+      # is propagated so torch.compile / Inductor can import the XPU backend.
+      propagatedBuildInputs =
+        (with final; [
+          filelock
+          typing-extensions
+          sympy
+          networkx
+          jinja2
+          fsspec
+        ])
+        ++ [ tritonXpu ];
       propagatedNativeBuildInputs = [ intelOneapiRuntime ];
       pythonImportsCheck = [ ];
       doCheck = false;

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -186,6 +186,149 @@
         hash = "sha256-pUuMH2HeAbGrlGWJqgFYId0RCTVEcCJJ0gq6VpE8aLs=";
       };
     };
+    # Linux x86_64 Intel XPU (oneAPI / SYCL)
+    # In-tree PyTorch XPU — no IPEX needed. Targets Arc A/B series and
+    # Core Ultra (Meteor Lake+) iGPUs. Older Xe-LP iGPUs (UHD 770) are
+    # not officially supported by Intel/PyTorch — untested here.
+    #
+    # The XPU torch wheel does NOT bundle its Intel runtime libs the way CUDA
+    # and ROCm wheels do. Instead it declares ~20 Intel runtime wheel deps in
+    # Requires-Dist. All are pinned in `xpuRuntime` below and wired up as
+    # propagatedBuildInputs of torch in python-overrides.nix.
+    xpu = {
+      torch = {
+        version = "2.10.0";
+        url = "https://download.pytorch.org/whl/xpu/torch-2.10.0%2Bxpu-cp312-cp312-linux_x86_64.whl";
+        hash = "sha256-tHNXHUeJEvkogcwT8V+hj4Rj+w+4oGjJbtR6fUWk2go=";
+      };
+      torchvision = {
+        version = "0.25.0";
+        url = "https://download.pytorch.org/whl/xpu/torchvision-0.25.0%2Bxpu-cp312-cp312-manylinux_2_28_x86_64.whl";
+        hash = "sha256-atJUNJa8KeWdPdYUqU0JqphwMYrttmBFNE//3f7dLPg=";
+      };
+      torchaudio = {
+        version = "2.10.0";
+        url = "https://download.pytorch.org/whl/xpu/torchaudio-2.10.0%2Bxpu-cp312-cp312-manylinux_2_28_x86_64.whl";
+        hash = "sha256-oD/un3Hi9OZC/P8vaokN6kYwm7cGrahDr40K5CBa4p8=";
+      };
+    };
+  };
+
+  # Intel XPU runtime wheel pins (declared as Requires-Dist by torch-2.10.0+xpu).
+  # These are PyPI-hosted wheels from Intel except triton-xpu which lives on
+  # download.pytorch.org. All are py2.py3-none-manylinux_2_28_x86_64 binary
+  # distributions containing .so files and Python shims.
+  xpuRuntime = {
+    intel-cmplr-lib-rt = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/3d/66/26dfd6a19f7faf595da12c21bdb4102c6f30755511c7f167f745b203fbb7/intel_cmplr_lib_rt-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-V/ZXqklEJyPlkQL7nj9etweZ2TceynqyrUb0T6zyEM8=";
+    };
+    intel-cmplr-lib-ur = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/70/9a/a338de7fc24087c40d38401372618c8465103795baefe941eea3acf55678/intel_cmplr_lib_ur-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-FzDM4MZVkdFX1foazchEep7UGbUn6lLmbbCBWg+15EQ=";
+    };
+    intel-cmplr-lic-rt = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/a7/3b/30ce9123fd5368ac4f9abceca8cd7ee2f495c3e2b6f1b244285737210a8d/intel_cmplr_lic_rt-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-rWUcJpBpK/jJQO5lomuwY9BpWafirSdyL27bvx9TykY=";
+    };
+    intel-sycl-rt = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/76/74/27684e2d0d32923da293f22b418c0c13919839444b67e86a8986f44938e7/intel_sycl_rt-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-KW2UWY4VC/bqTFqPFQX5jopIO/OLaTW43a1vcrHSW58=";
+    };
+    oneccl-devel = {
+      version = "2021.17.1";
+      url = "https://files.pythonhosted.org/packages/6f/69/761af812bbccc4decd4f5b7492aa533654773ae9dfc3487edec44a4d8126/oneccl_devel-2021.17.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-w/dDjxK5dj3SvLPOT0iyRieIU0lHVFpoEX9QO5qwHSo=";
+    };
+    oneccl = {
+      version = "2021.17.1";
+      url = "https://files.pythonhosted.org/packages/3d/69/8050e96e5b099b349d9109f727ce39b4f57414a24d3eb71a12fdc48bad87/oneccl-2021.17.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-x3sWoWhtJS7OffMx2o5P7rN3bEC90DqPjplCrTeNj/g=";
+    };
+    impi-rt = {
+      version = "2021.17.0";
+      url = "https://files.pythonhosted.org/packages/26/f9/4d676df06d5069144d1533a52860401ae9204cfe84ab69dc59a595233464/impi_rt-2021.17.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-e2XFpenfii/gzJjuWkTqThj5Dn0RhHq2ufmw31nB0Do=";
+    };
+    onemkl-license = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/88/11/b43e8cde058c368ce7f8f9b1ca9f812f7397e4309148da7d24cb6b81b513/onemkl_license-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-qBCyW7JKkNtEktgccc3hMYPYlRziaWDW3FbU9OPclf8=";
+    };
+    onemkl-sycl-blas = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/1e/07/df0cd5b0ec5f0a0bcbc8e73e4b2cfca78449b3b521868b1e366bfe6f97a3/onemkl_sycl_blas-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-57tfKK/ARfy72JiRT0d9fnU17J+0W7lG7Z+Be9HvH1s=";
+    };
+    onemkl-sycl-dft = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/7c/b8/1ec88922a9a479f567183cf82d49041451bcb7afbb3195202d9a57e5a0ff/onemkl_sycl_dft-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-OuI/OCDwZRyLQ8/2Rt3STawpOCr2yyS/RtXIpHLIuJk=";
+    };
+    onemkl-sycl-lapack = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/78/c4/c2cf3e1990707f7f1918f1073e3a26c56e92f06c1525af39501b271ede23/onemkl_sycl_lapack-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-0qTXuia5CrM6L2TtbJXFlshyHuJRmD6vmkyYVtHjTHs=";
+    };
+    onemkl-sycl-rng = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/94/6a/3fc34f47c69bdfbfce1f6d02f18e0fd41459bb4e1204e2a5cae179c0986e/onemkl_sycl_rng-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-5EBkG3waAhxJdblbmYKLgBVQSNiQ6/0k80Bg/qpbM3U=";
+    };
+    onemkl-sycl-sparse = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/a9/5f/4f0b81e5f83f5e42c549bd29a9398b507890ec24080d27cd7afada61521e/onemkl_sycl_sparse-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-kwzS0UquWhv+wH+hC4F8REeDRTqhplVA3kbgy/nQDeY=";
+    };
+    dpcpp-cpp-rt = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/9a/1f/ff1b20fe45c1a2077f1a11e2447826881987a76983facab763a72ee29fc8/dpcpp_cpp_rt-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-ZWTxncV0XAC0nqdJUt8TwmxOI6ogtykpKKMNdeOE+YY=";
+    };
+    intel-opencl-rt = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/8b/de/6a4fa1e6e1ff1441a4197f08c92798367074f98e4f43ce0d94f36913ae90/intel_opencl_rt-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-9Ux5f9g5ueXkQciU6rDhrcg5SgazxN84BFItYAWmYdk=";
+    };
+    mkl = {
+      version = "2025.3.0";
+      url = "https://files.pythonhosted.org/packages/6d/b4/ef531295ed33b929c6c5214421eeebe370f1be22536b6956b4aaf18fdbc5/mkl-2025.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-e4H10uA0Y3sYfKWGZoeMToiJmIp4454LbukuhGVo9mA=";
+    };
+    intel-openmp = {
+      version = "2025.3.1";
+      url = "https://files.pythonhosted.org/packages/da/ad/72e2fb7e30f5fd2b7650b721c5979cf2a614538fd99afb45672b31157fb9/intel_openmp-2025.3.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-LDVB6idfDoQXJDYSoWtvH00Vwen8yWZn2wgk0HNfFBM=";
+    };
+    tbb = {
+      version = "2022.3.0";
+      url = "https://files.pythonhosted.org/packages/e3/9e/b7f1f7af53580e4e8cf39cf51b14c8e295d767b3ae9d78b5007d6058cfc8/tbb-2022.3.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-p+Eiy5im+II5QDQaoyPc3/+nfjZxKiKhrjp2Qw+p9BI=";
+    };
+    tcmlib = {
+      version = "1.4.1";
+      url = "https://files.pythonhosted.org/packages/a1/a4/38e8b5a27b66ab286168ba6c449771ed71d71ec76524e7f12401474a5151/tcmlib-1.4.1-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-DVvZjbSNMb7H/tulwjWZv5rkPHAW1MOUbSUkLTIM7ok=";
+    };
+    umf = {
+      version = "1.0.2";
+      url = "https://files.pythonhosted.org/packages/27/8e/4a90b6aa955268988e7491f502b7ac2bd65cb954b4979bfcc892cf019b50/umf-1.0.2-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-700USiAHpzoaIu5XXuT1oYlKIGUyxvbXe0z1SGQ1Avs=";
+    };
+    intel-pti = {
+      version = "0.15.0";
+      url = "https://files.pythonhosted.org/packages/f4/f0/56874c288e637e1b8619813d5a928778a712e96456f19a2ca1f52b4c9eb0/intel_pti-0.15.0-py2.py3-none-manylinux_2_28_x86_64.whl";
+      hash = "sha256-Yp+9+0wXAZh9zJ+OLAP8GLPsmrXIRi7p3nHJbGK4Lsw=";
+    };
+    triton-xpu = {
+      version = "3.6.0";
+      url = "https://download.pytorch.org/whl/triton_xpu-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-e6neluXTZAC5lrn7nrOEQxlkU678Efr+GnuyJrxfuLs=";
+    };
   };
 
   # Custom nodes with pinned versions


### PR DESCRIPTION
## Summary
Closes #50. Adds a fourth GPU backend alongside CPU/CUDA/ROCm, using pre-built `torch 2.10.0+xpu` wheels from `pytorch.org/whl/xpu`. In-tree `torch.xpu` — no IPEX required.

Supported hardware (per PyTorch XPU docs):
- Intel Arc A-series (Alchemist) + B-series (Battlemage) discrete
- Core Ultra iGPUs: Meteor Lake, Arrow Lake, Lunar Lake, Panther Lake
- Data Center GPU Max (Ponte Vecchio)

Older Xe-LP iGPUs (UHD 770) are **not officially supported** by Intel/PyTorch; may or may not work.

## The tricky part — Intel runtime packaging

Unlike the CUDA and ROCm wheels (which bundle their GPU runtime libraries internally), the XPU torch wheel declares its Intel runtime as **22 separate PyPI wheels** in `Requires-Dist`: SYCL, oneMKL (blas/dft/lapack/rng/sparse), oneCCL, Intel compiler RT, Intel OpenMP, TBB, intel-pti, triton-xpu, etc.

All 22 are pinned in `nix/versions.nix:xpuRuntime` and combined into a single `intel-oneapi-runtime` stdenv derivation in `nix/python-overrides.nix`. The combined derivation unpacks all wheels' `.data/data/lib/` contents into one `$out/lib/`, which becomes `torch`'s `buildInput` so `auto-patchelf` resolves all cross-wheel SONAME references (libsycl.so.8, libmkl_sycl_*.so.5, libccl.so.1, libumf.so.1, etc.) in a single RPATH entry.

Initial attempts with 22 individual `buildPythonPackage` derivations cross-referencing each other triggered infinite recursion through `requiredPythonModules`. The combined-derivation approach sidesteps that and results in a simpler, smaller-closure implementation.

## Host driver strategy (hybrid NixOS + non-NixOS)

The wheels ship the SYCL runtime, but the host must provide:
- Kernel driver: `i915` (Arc Alchemist) or `xe` (Battlemage, newer iGPUs)
- Userland: Level Zero loader + Intel compute-runtime + OpenCL ICD

The launcher prefers `/run/opengl-driver/lib` (NixOS `hardware.graphics.extraPackages`) when present, and falls back to Nix-bundled `pkgs.level-zero` + `pkgs.intel-compute-runtime` + `pkgs.ocl-icd` for non-NixOS Linux (Ubuntu, Arch, Docker). This keeps the userland ICD in sync with the kernel DRM driver on NixOS while still giving other distros a working package.

## Env var behavior

| Var | Default | Purpose |
|-----|---------|---------|
| `SYCL_CACHE_PERSISTENT=1` | always on | Cache JIT kernels across runs (big first-run vs. subsequent speedup) |
| `SYCL_CACHE_DIR` | `<data-dir>/.cache/libsycl_cache` | Follows project convention for caches |
| `COMFY_ENABLE_XPU_FP64_EMULATION=1` | **off**, user opt-in | Enables `OverrideDefaultFP64Settings` + `IGC_EnableDPEmulation` for iGPUs without native FP64. Off by default so discrete Arc surfaces real errors rather than silently emulating |

## Non-regression verification

All XPU paths are gated on `stdenv.isLinux && stdenv.hostPlatform.isx86_64`. Verified:

| System | `.#default` evals | `.#xpu` exposed? |
|--------|-------------------|-------------------|
| x86_64-linux | ✅ | ✅ (plus `.#cuda`, `.#rocm`) |
| aarch64-darwin (Metal) | ✅ | correctly absent |
| x86_64-darwin | ✅ | correctly absent |
| aarch64-linux | ✅ | correctly absent |

`nix flake check -L` passes on x86_64-linux: ruff, pyright, nixfmt, shellcheck, pytest, `package` (CPU), and new `package-xpu` all green.

## New surfaces

- Package: `.#xpu`, overlay `pkgs.comfy-ui-xpu`
- Docker: `.#dockerImageXpu`, `.#dockerImageLinuxXpu` (cross-build)
- App: `nix run .#xpu`, `nix run .#buildDockerXpu`

## Test plan

- [x] `nix flake check -L` on x86_64-linux passes
- [x] `nix build .#xpu` succeeds end-to-end (torch imports, open-clip-torch pythonImportsCheck passes → full oneAPI runtime resolution works in the build sandbox)
- [x] Darwin + aarch64-linux eval unchanged; XPU correctly not exposed
- [ ] **Runtime testing requested from community** — maintainer has no Intel GPU. See [Issue #50](https://github.com/utensils/comfyui-nix/issues/50). Please report:
  - Hardware (GPU model, CPU if iGPU)
  - Kernel version + driver (`uname -r`, `lsmod | grep -E "i915|xe"`)
  - `clinfo --list` / `sycl-ls` output
  - Whether image generation completes without `libze_loader` / FP64 / SYCL errors
  - If FP64 emulation opt-in is needed (`COMFY_ENABLE_XPU_FP64_EMULATION=1`)

## Docs updates
- README: new "Intel XPU (oneAPI / SYCL) Support" section, quick-start in intro, overlay/profile/Docker tables updated
- CLAUDE.md: GPU architecture notes extended with XPU specifics, env vars, hardware gating rule