### PR TITLE
fix+feat: skip pythonRuntimeDepsCheck for known-broken wheels; add bundledNodes opt-out

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -115,16 +115,20 @@
             pkgs:
             {
               gpuSupport ? "none",
+              bundledNodes ? null,
             }:
-            import ./nix/packages.nix {
-              inherit
-                pkgs
-                versions
-                gpuSupport
-                ;
-              lib = pkgs.lib;
-              pythonOverrides = pythonOverridesFor pkgs gpuSupport;
-            };
+            import ./nix/packages.nix (
+              {
+                inherit
+                  pkgs
+                  versions
+                  gpuSupport
+                  ;
+                lib = pkgs.lib;
+                pythonOverrides = pythonOverridesFor pkgs gpuSupport;
+              }
+              // (if bundledNodes != null then { inherit bundledNodes; } else { })
+            );
 
           # Linux packages for Docker image cross-builds
           linuxX86Packages = mkComfyPackages pkgsLinuxX86 { };
@@ -210,9 +214,20 @@
             dockerImageXpu = nativePackagesXpu.dockerImageXpu;
           };
 
-          # Expose custom nodes for direct use
+          # Expose custom nodes for direct use, plus mkComfyPackages so
+          # downstreams can build a comfy-ui derivation with their own
+          # bundledNodes selection (or other overrides).
+          #
+          # Example consumer usage (NixOS):
+          #
+          #   services.comfyui.package = (
+          #     inputs.comfyui-nix.legacyPackages.x86_64-linux.mkComfyPackages
+          #       pkgs
+          #       { gpuSupport = "rocm"; bundledNodes = [ "impact-pack" "rgthree-comfy" ]; }
+          #   ).default;
           legacyPackages = {
             customNodes = customNodes;
+            mkComfyPackages = mkComfyPackages;
           };
 
           apps = import ./nix/apps.nix {

--- a/nix/custom-nodes.nix
+++ b/nix/custom-nodes.nix
@@ -38,6 +38,8 @@ let
       runHook postInstall
     '';
 
+    passthru.installDirName = "ComfyUI-Impact-Pack";
+
     # Python dependencies required by Impact Pack
     passthru.pythonDeps =
       ps: with ps; [
@@ -50,6 +52,7 @@ let
         dill
         segment-anything
         sam2
+        ultralytics # Impact Subpack: YOLO object detection
       ];
 
     meta = with lib; {
@@ -101,6 +104,8 @@ let
       runHook postInstall
     '';
 
+    passthru.installDirName = "rgthree-comfy";
+
     # No additional Python dependencies needed
     passthru.pythonDeps = ps: [ ];
 
@@ -133,12 +138,15 @@ let
       runHook postInstall
     '';
 
+    passthru.installDirName = "ComfyUI-KJNodes";
+
     # Python dependencies required by KJNodes
     passthru.pythonDeps =
-      ps: with ps; [
-        color-matcher
-        mss
-      ];
+      ps:
+      [
+        ps."color-matcher" # hyphenated name needs quoting
+      ]
+      ++ (with ps; [ mss ]);
 
     meta = with lib; {
       description = "ComfyUI KJNodes - Various utility nodes";
@@ -168,6 +176,8 @@ let
       cp -r . $out/
       runHook postInstall
     '';
+
+    passthru.installDirName = "ComfyUI-GGUF";
 
     # Python dependencies required by ComfyUI-GGUF
     passthru.pythonDeps =
@@ -206,6 +216,8 @@ let
       runHook postInstall
     '';
 
+    passthru.installDirName = "ComfyUI-LTXVideo";
+
     passthru.pythonDeps =
       ps: with ps; [
         diffusers
@@ -243,6 +255,8 @@ let
       cp -r . $out/
       runHook postInstall
     '';
+
+    passthru.installDirName = "ComfyUI-Florence2";
 
     passthru.pythonDeps =
       ps: with ps; [
@@ -283,6 +297,12 @@ let
       runHook postInstall
     '';
 
+    passthru.installDirName = "ComfyUI_bitsandbytes_NF4";
+
+    # Linux-only at the symlink level (bitsandbytes requires CUDA); the
+    # python deps are still safe to evaluate cross-platform.
+    passthru.linuxOnly = true;
+
     passthru.pythonDeps =
       ps: with ps; [
         bitsandbytes
@@ -316,6 +336,8 @@ let
       cp -r . $out/
       runHook postInstall
     '';
+
+    passthru.installDirName = "x-flux-comfyui";
 
     passthru.pythonDeps =
       ps: with ps; [
@@ -355,6 +377,8 @@ let
       cp -r . $out/
       runHook postInstall
     '';
+
+    passthru.installDirName = "ComfyUI-MMAudio";
 
     passthru.pythonDeps =
       ps: with ps; [
@@ -397,6 +421,8 @@ let
       runHook postInstall
     '';
 
+    passthru.installDirName = "PuLID_ComfyUI";
+
     # Face analysis dependencies - insightface works on all platforms via onnxruntime
     # (mxnet dependency is removed in python-overrides.nix for cross-platform support)
     passthru.pythonDeps =
@@ -436,6 +462,8 @@ let
       cp -r . $out/
       runHook postInstall
     '';
+
+    passthru.installDirName = "ComfyUI-WanVideoWrapper";
 
     passthru.pythonDeps =
       ps: with ps; [

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -4,6 +4,23 @@
   versions,
   pythonOverrides,
   gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
+  # Bundled custom nodes to include. Each name must be an attribute key of
+  # ./custom-nodes.nix. Override with a subset (or `[]`) to skip nodes you
+  # don't need — their Python deps and symlinks are then dropped from the
+  # build. Default keeps full upstream behaviour for backwards compatibility.
+  bundledNodes ? [
+    "impact-pack"
+    "rgthree-comfy"
+    "kjnodes"
+    "gguf"
+    "ltxvideo"
+    "florence2"
+    "bitsandbytes-nf4"
+    "x-flux"
+    "mmaudio"
+    "pulid"
+    "wanvideo"
+  ],
 }:
 let
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
@@ -56,6 +73,27 @@ let
       versions
       ;
   };
+
+  # Validate that every entry in bundledNodes points at a real custom node.
+  # A typo otherwise silently disables the node, which is a footgun.
+  unknownBundled = lib.subtractLists (lib.attrNames customNodes) bundledNodes;
+  _ = lib.throwIf (unknownBundled != [ ]) ''
+    services.comfyui (or packages.nix bundledNodes): unknown node name(s):
+      ${lib.concatStringsSep ", " unknownBundled}
+    Known nodes: ${lib.concatStringsSep ", " (lib.attrNames customNodes)}
+  '' null;
+
+  # Selected nodes after applying platform constraints (e.g. the bitsandbytes
+  # NF4 wheel only builds on Linux). passthru.linuxOnly opt-out drops them on
+  # Darwin without forcing the user to maintain a per-platform list.
+  effectiveBundledNodes = lib.filter (
+    name:
+    let
+      node = customNodes.${name};
+      linuxOnly = node.passthru.linuxOnly or false;
+    in
+    !(linuxOnly && pkgs.stdenv.isDarwin)
+  ) bundledNodes;
 
   comfyuiSrcRaw = pkgs.fetchFromGitHub {
     owner = "Comfy-Org";
@@ -144,51 +182,26 @@ let
         pydantic-settings
         simpleeval
       ];
-      # ComfyUI Manager and common custom node dependencies
+      # ComfyUI Manager runtime + always-on helpers (independent of which
+      # custom nodes are bundled — the manager is part of ComfyUI core, and
+      # opencv4 / imageio-ffmpeg are pulled in by enough runtime-installed
+      # nodes that having them ready avoids surprise pip failures).
       extras =
         with ps;
         [
-          pip # Required for comfyui-manager security check
-          uv # Required for comfyui-manager package management
-          chardet # Required for comfyui-manager to read requirements.txt files
-          pygithub # Required for comfyui-manager GitHub integration
-          typer # Required for comfyui-manager CLI
-          matrix-nio # Optional: enables ComfyUI-Manager matrix sharing feature
-          opencv4 # Required by many custom nodes for image processing (cv2)
-          imageio-ffmpeg # Required by VideoHelperSuite and other video nodes
-          # Impact Pack dependencies
-          scikit-image # Image processing (skimage)
-          piexif # EXIF metadata handling
-          matplotlib # Plotting and visualization
-          dill # Extended pickling
-          segment-anything # Meta AI SAM model
-          sam2 # Meta AI SAM 2 model
-          # Impact Subpack dependencies
-          ultralytics # YOLO object detection (for UltralyticsDetectorProvider)
-          # KJNodes dependencies
-          mss # Screen capture
-          # General ML utilities
-          accelerate # HuggingFace Accelerate for distributed training/inference
-          # ComfyUI-GGUF dependencies
-          gguf # GGUF file format support
-          protobuf # Required for GGUF tokenizer support
-          # LTXVideo dependencies
-          diffusers # Diffusion models
-          huggingface-hub # HuggingFace Hub
-          timm # PyTorch Image Models
-          # Florence2 dependencies
-          peft # Parameter-efficient fine-tuning
-          # MMAudio dependencies
-          librosa # Audio processing
-          torchdiffeq # Differential equations solver
-          omegaconf # Configuration management
-          open-clip-torch # OpenCLIP
-          ftfy # Text encoding fixes
-          # PuLID dependencies
-          onnxruntime # ONNX runtime
+          # ComfyUI Manager runtime
+          pip # security check
+          uv # package management
+          chardet # requirements.txt reading
+          pygithub # GitHub integration
+          typer # CLI
+          matrix-nio # matrix sharing feature (optional)
+          # Widely-needed across ComfyUI core + many runtime-installed nodes
+          opencv4 # cv2
+          imageio-ffmpeg # video helpers
+          accelerate # general HuggingFace utility
         ]
-        ++ [ ps."color-matcher" ] # Color matching (hyphenated name needs quoting)
-        # Common custom-node deps ("it just works" set)
+        # Common runtime-node deps ("it just works" set)
         ++ lib.optionals (ps ? ollama && available ps.ollama) [ ps.ollama ]
         ++ lib.optionals (ps ? "pytorch-lightning" && available ps."pytorch-lightning") [
           ps."pytorch-lightning"
@@ -199,6 +212,13 @@ let
         ++ lib.optionals (ps ? "google-generativeai" && available ps."google-generativeai") [
           ps."google-generativeai"
         ];
+
+      # Per-plugin Python deps, gated on the user's bundledNodes selection.
+      # Each custom node declares its own deps via passthru.pythonDeps in
+      # custom-nodes.nix; this avoids duplicating the dep list in two places.
+      selectedNodeDeps = lib.concatMap (
+        name: customNodes.${name}.passthru.pythonDeps ps
+      ) effectiveBundledNodes;
       # torch is overridden at the base level in python-overrides.nix when when gpuSupport="cuda|rocm"
       # so ps.torch is already CUDA/ROCm-enabled when building with CUDA/ROCm support
       torchPackages = lib.optionals (ps ? torch && available ps.torch) [ ps.torch ];
@@ -220,13 +240,11 @@ let
         ++ lib.optionals (ps ? toml && available ps.toml) [ ps.toml ]
         ++ lib.optionals (ps ? rich && available ps.rich) [ ps.rich ]
         ++ lib.optionals (ps ? "comfy-cli" && available ps."comfy-cli") [ ps."comfy-cli" ]
-        # Linux-only packages (CUDA dependencies)
-        ++ lib.optionals (pkgs.stdenv.isLinux && ps ? bitsandbytes) [ ps.bitsandbytes ]
+        # Linux-only attention/quantisation runtimes that aren't tied to a
+        # specific bundled node. (bitsandbytes itself is now a per-plugin dep
+        # of bitsandbytes-nf4 — see custom-nodes.nix.)
         ++ lib.optionals (pkgs.stdenv.isLinux && ps ? xformers) [ ps.xformers ]
         ++ lib.optionals (pkgs.stdenv.isLinux && ps ? triton && available ps.triton) [ ps.triton ]
-        # Face analysis packages - work on all platforms (insightface override removes mxnet)
-        ++ lib.optionals (ps ? insightface) [ ps.insightface ]
-        ++ lib.optionals (ps ? facexlib) [ ps.facexlib ]
         ++ [
           vendored.comfyuiFrontendPackage
           vendored.comfyuiWorkflowTemplates
@@ -239,7 +257,7 @@ let
           vendored.sageattention
         ];
     in
-    base ++ extras ++ optionals
+    base ++ extras ++ selectedNodeDeps ++ optionals
   );
 
   frontendRoot = "${pythonRuntime}/${python.sitePackages}/comfyui_frontend_package/static";
@@ -423,19 +441,29 @@ let
               fi
             fi
 
-            # Link our bundled custom nodes
-            # Remove stale directories if they exist but aren't symlinks
-            for node_dir in "model_downloader" "ComfyUI-Impact-Pack" "rgthree-comfy" "ComfyUI-KJNodes" "ComfyUI-GGUF" "ComfyUI-LTXVideo" "ComfyUI-Florence2" "ComfyUI_bitsandbytes_NF4" "x-flux-comfyui" "ComfyUI-MMAudio" "PuLID_ComfyUI" "ComfyUI-WanVideoWrapper"; do
+            # Link our bundled custom nodes.
+            # Cleanup pass covers every known node dir (regardless of the
+            # current bundledNodes selection) so dropping a plugin removes
+            # its stale store symlink on the next launch.
+            for node_dir in "model_downloader" ${
+              lib.concatMapStringsSep " " (
+                node: "\"${node.passthru.installDirName}\""
+              ) (lib.attrValues customNodes)
+            }; do
               if [[ -e "$BASE_DIR/custom_nodes/$node_dir" && ! -L "$BASE_DIR/custom_nodes/$node_dir" ]]; then
                 rm -rf "$BASE_DIR/custom_nodes/$node_dir"
               fi
+              # Also drop stale symlinks for nodes that were previously
+              # bundled but are no longer in bundledNodes.
+              if [[ -L "$BASE_DIR/custom_nodes/$node_dir" ]] && \
+                 ! [[ "$node_dir" =~ ^(model_downloader${
+                   lib.concatMapStringsSep "" (
+                     name: "|${customNodes.${name}.passthru.installDirName}"
+                   ) effectiveBundledNodes
+                 })$ ]]; then
+                rm -f "$BASE_DIR/custom_nodes/$node_dir"
+              fi
             done
-
-            # On macOS, remove Linux-only nodes if they were linked previously
-            # Note: PuLID now works on macOS via CoreML (insightface override removes mxnet dependency)
-            if [[ "$(uname)" == "Darwin" ]]; then
-              rm -f "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" 2>/dev/null || true
-            fi
 
             # Clean up stale read-only web extension directories (from Nix store)
             if [[ -d "$BASE_DIR/web/extensions" ]]; then
@@ -444,22 +472,13 @@ let
 
             # Link bundled nodes (always update symlinks to pick up new Nix store paths)
             ln -sfn "${modelDownloaderDir}" "$BASE_DIR/custom_nodes/model_downloader"
-            ln -sfn "${customNodes.impact-pack}" "$BASE_DIR/custom_nodes/ComfyUI-Impact-Pack"
-            ln -sfn "${customNodes.rgthree-comfy}" "$BASE_DIR/custom_nodes/rgthree-comfy"
-            ln -sfn "${customNodes.kjnodes}" "$BASE_DIR/custom_nodes/ComfyUI-KJNodes"
-            ln -sfn "${customNodes.gguf}" "$BASE_DIR/custom_nodes/ComfyUI-GGUF"
-            ln -sfn "${customNodes.ltxvideo}" "$BASE_DIR/custom_nodes/ComfyUI-LTXVideo"
-            ln -sfn "${customNodes.florence2}" "$BASE_DIR/custom_nodes/ComfyUI-Florence2"
-            # bitsandbytes requires CUDA (Linux-only)
-            if [[ "$(uname)" != "Darwin" ]]; then
-              ln -sfn "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
-            fi
-            ln -sfn "${customNodes.x-flux}" "$BASE_DIR/custom_nodes/x-flux-comfyui"
-            ln -sfn "${customNodes.mmaudio}" "$BASE_DIR/custom_nodes/ComfyUI-MMAudio"
-            # PuLID - face ID for consistent face generation
-            # Works on all platforms: Linux uses CUDA, macOS uses CoreML via onnxruntime
-            ln -sfn "${customNodes.pulid}" "$BASE_DIR/custom_nodes/PuLID_ComfyUI"
-            ln -sfn "${customNodes.wanvideo}" "$BASE_DIR/custom_nodes/ComfyUI-WanVideoWrapper"
+            ${lib.concatMapStringsSep "\n            " (
+              name:
+              let
+                node = customNodes.${name};
+              in
+              ''ln -sfn "${node}" "$BASE_DIR/custom_nodes/${node.passthru.installDirName}"''
+            ) effectiveBundledNodes}
 
             # Create default ComfyUI-Manager config if it doesn't exist
             # Note: Manager moved config from user/default/ComfyUI-Manager to user/__manager

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -999,6 +999,10 @@ lib.optionalAttrs useCuda {
     '';
 
     doCheck = false;
+    # Wheel's Requires-Dist asks for opencv-python and tqdm; we provide
+    # opencv4 (the same library under nixpkgs's name) plus tqdm transitively
+    # via the surrounding env. pythonImportsCheck guards real import surface.
+    dontCheckRuntimeDeps = true;
     pythonImportsCheck = [ "facexlib" ];
   };
 }

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -144,6 +144,12 @@ lib.optionalAttrs useCuda {
     # Don't check for CUDA at import time (requires GPU)
     pythonImportsCheck = [ ];
     doCheck = false;
+    # Wheel's Requires-Dist lists `nvidia-*` and `triton` runtime deps that
+    # are provided by nixpkgs cudaPackages or bundled in the wheel, not
+    # available as PyPI packages. The postInstall sed strips them from the
+    # *installed* METADATA, but pythonRuntimeDepsCheckHook runs before
+    # postInstall, so we need to disable it explicitly here.
+    dontCheckRuntimeDeps = true;
 
     # Passthru attributes expected by downstream packages (xformers, bitsandbytes, etc.)
     # The wheel bundles CUDA 12.8 and supports all GPU architectures
@@ -392,6 +398,14 @@ lib.optionalAttrs useCuda {
     # Don't check for ROCm at import time (requires GPU)
     pythonImportsCheck = [ ];
     doCheck = false;
+    # Wheel's Requires-Dist lists `setuptools` and `triton-rocm` as runtime
+    # deps. setuptools is build-time only at the Python level (the wheel
+    # doesn't import it eagerly), and triton-rocm isn't a separate package
+    # in nixpkgs — it's bundled in the upstream rocm torch wheel itself.
+    # The postInstall sed above strips triton-rocm from the *installed*
+    # METADATA, but pythonRuntimeDepsCheckHook runs before postInstall, so
+    # we need to disable it explicitly here.
+    dontCheckRuntimeDeps = true;
 
     # Passthru attributes expected by downstream packages (xformers, bitsandbytes, etc.)
     # The wheel bundles ROCm 7.1 and supports all GPU architectures

--- a/nix/vendored-packages.nix
+++ b/nix/vendored-packages.nix
@@ -11,9 +11,15 @@ let
       url,
       hash,
       propagatedBuildInputs ? [ ],
+      dontCheckRuntimeDeps ? false,
     }:
     python.pkgs.buildPythonPackage {
-      inherit pname version propagatedBuildInputs;
+      inherit
+        pname
+        version
+        propagatedBuildInputs
+        dontCheckRuntimeDeps
+        ;
       format = "wheel";
       src = pkgs.fetchurl { inherit url hash; };
       doCheck = false;
@@ -88,6 +94,13 @@ rec {
     version = versions.vendored.manager.version;
     url = versions.vendored.manager.url;
     hash = versions.vendored.manager.hash;
+    # Wheel's Requires-Dist lists gitpython, pygithub, transformers,
+    # huggingface-hub, typer, rich, typing-extensions, toml, uv, and chardet
+    # as mandatory runtime deps. They are provided by the surrounding ComfyUI
+    # pythonRuntime (see `extras` in nix/packages.nix), not propagated by this
+    # wheel itself, so the per-package pythonRuntimeDepsCheckHook fails the
+    # standalone build under newer nixpkgs that enable the hook by default.
+    dontCheckRuntimeDeps = true;
   };
 
   comfyKitchen = mkWheel {
@@ -117,6 +130,10 @@ rec {
       typing-extensions
       websockets
     ];
+    # Wheel pins websockets<16.0; newer nixpkgs ships websockets 16.x. The
+    # gradio-client API surface used by ComfyUI custom nodes is unaffected
+    # by the major bump, so skip the standalone runtime version check.
+    dontCheckRuntimeDeps = true;
   };
 
   gradio = mkWheel {
@@ -154,6 +171,11 @@ rec {
       typing-extensions
       uvicorn
     ];
+    # Same as gradio-client: wheel constrains several deps to versions that
+    # have moved on in newer nixpkgs. The propagatedBuildInputs above pull
+    # in the current versions, which work in practice for the surfaces
+    # ComfyUI uses.
+    dontCheckRuntimeDeps = true;
   };
 
   sageattention = mkWheel {


### PR DESCRIPTION
This PR has two related changes — happy to split if you'd prefer.

## 1. fix: skip pythonRuntimeDepsCheck for vendored wheels under newer nixpkgs

Several vendored wheels fail their standalone build under newer nixpkgs that enable `pythonRuntimeDepsCheckHook` by default. The deps are either provided by the surrounding ComfyUI runtime (so the per-package check is spurious) or pinned at versions that have moved on:

| Wheel | Issue |
|---|---|
| `comfyui-manager` 4.1 | Requires-Dist lists gitpython, pygithub, transformers, huggingface-hub, typer, rich, typing-extensions, toml, uv, chardet — provided by `extras` in `nix/packages.nix` |
| `gradio-client` 1.13.3 | Pins `websockets<16.0`; newer nixpkgs ships 16.x |
| `gradio` 5.49.1 | Same pattern as gradio-client |
| `facexlib` 0.3.0 | Asks for `opencv-python` and `tqdm`; we provide `opencv4` (same lib, different nixpkgs name) and `tqdm` via the surrounding env |
| `torch` (CUDA + ROCm pre-built wheels) | Wheel asks for `nvidia-*`/`triton`/`triton-rocm`/`setuptools`; the existing `postInstall` sed strips them from the *installed* METADATA, but the runtime check runs *before* postInstall |

Matches the precedent from 032c231 (color-matcher fix in #53):
- Add `dontCheckRuntimeDeps` parameter to `mkWheel` (mirrors the existing `propagatedBuildInputs ? []`).
- Set `dontCheckRuntimeDeps = true` on each affected wheel.

`pythonImportsCheck` (where applicable) still guards real import surface.

## 2. feat: make bundled custom nodes opt-out via `bundledNodes` parameter

`packages.nix:pythonRuntime` previously hard-coded the Python deps for every bundled node (mss for KJNodes, sam2 for Impact Pack, librosa for MMAudio, etc.) directly in `extras`, *and* hard-coded the symlink/cleanup loops. Each node already had its own `passthru.pythonDeps` in `custom-nodes.nix`, but they were duplicated rather than consumed.

This change:
- Adds `bundledNodes` parameter to `packages.nix` (default keeps every current plugin → backwards compatible).
- Adds `passthru.installDirName` to every node so symlinks/cleanup are generated from a single source of truth.
- Adds `passthru.linuxOnly` for nodes that can't build on Darwin (currently only `bitsandbytes-nf4`); these are filtered out automatically instead of being special-cased in the bash launcher.
- Replaces the hard-coded plugin-deps section of `extras` with a `concatMap` over each selected node's `passthru.pythonDeps`.
- Removes from `optionals` deps now sourced per-plugin (`bitsandbytes` ← bitsandbytes-nf4, `insightface`/`facexlib` ← pulid).
- Replaces the static cleanup + symlink blocks with ones generated from `effectiveBundledNodes`, including stale-symlink cleanup for nodes the user has just removed.
- Exposes `mkComfyPackages` via `legacyPackages.<system>` so downstream NixOS configs can:

  ```nix
  services.comfyui.package = (
    inputs.comfyui-nix.legacyPackages.x86_64-linux.mkComfyPackages
      pkgs
      { gpuSupport = "rocm"; bundledNodes = [ "impact-pack" "rgthree-comfy" ]; }
  ).default;
  ```

Resolves the practical "I don't use these plugins, I shouldn't pay for their wheels" case where e.g. KJNodes' `mss` dep fails to build under newer nixpkgs but the user doesn't actually need KJNodes.

## Test plan
- [x] `nix flake check` passes
- [x] `nix build .#packages.x86_64-linux.rocm` succeeds (previously failed at `comfyui-manager`)
- [x] Consumer build via `inputs.self.legacyPackages.x86_64-linux.mkComfyPackages` against newer nixpkgs (nixos-unstable @ 2026-04-30) with `bundledNodes = []` builds cleanly end-to-end
- [x] Default `bundledNodes` value is unchanged so existing consumers see no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)