### PR TITLE
fix(cuda): disable cuda malloc on Blackwell GPUs

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -605,10 +605,11 @@ let
                   grep -E '^Model:' "$gpu_info" 2>/dev/null || true
                 fi
               done
+              return 0
             }
 
             if detect_nvidia_gpus | grep -Eiq 'GeForce RTX 50[0-9]{2}|RTX PRO .*Blackwell|Blackwell|NVIDIA B[0-9]{3}'; then
-              echo "Detected NVIDIA Blackwell GPU with CUDA 12.x PyTorch; adding --disable-cuda-malloc for stability."
+              echo "Detected NVIDIA Blackwell GPU; adding --disable-cuda-malloc for stability."
               COMFY_ARGS+=("--disable-cuda-malloc")
             fi
             ;;

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -577,6 +577,44 @@ let
             export FACEXLIB_MODELPATH="$BASE_DIR/.cache/facexlib"
             mkdir -p "$FACEXLIB_MODELPATH/facexlib/weights"
 
+      ${lib.optionalString useCuda ''
+        # =====================================================================
+        # NVIDIA Blackwell / CUDA 12.x compatibility
+        # =====================================================================
+        # ComfyUI enables cudaMallocAsync automatically for CUDA builds unless a
+        # device is explicitly blacklisted. On Blackwell cards with the current
+        # cu128 PyTorch wheels, users have reported generation-time crashes and
+        # ComfyUI's own warning recommends --disable-cuda-malloc for allocator
+        # errors. Disable it automatically for RTX 50/Blackwell unless the user
+        # already selected an allocator mode in extraArgs.
+        case " ''${COMFY_ARGS[*]} " in
+          *" --disable-cuda-malloc "*|*" --cuda-malloc "*)
+            ;;
+          *)
+            detect_nvidia_gpus() {
+              if command -v nvidia-smi >/dev/null 2>&1; then
+                nvidia-smi -L 2>/dev/null && return 0
+              fi
+              for nvidia_smi in /run/current-system/sw/bin/nvidia-smi /run/opengl-driver/bin/nvidia-smi; do
+                if [[ -x "$nvidia_smi" ]]; then
+                  "$nvidia_smi" -L 2>/dev/null && return 0
+                fi
+              done
+              for gpu_info in /proc/driver/nvidia/gpus/*/information; do
+                if [[ -r "$gpu_info" ]]; then
+                  grep -E '^Model:' "$gpu_info" 2>/dev/null || true
+                fi
+              done
+            }
+
+            if detect_nvidia_gpus | grep -Eiq 'GeForce RTX 50[0-9]{2}|RTX PRO .*Blackwell|Blackwell|NVIDIA B[0-9]{3}'; then
+              echo "Detected NVIDIA Blackwell GPU with CUDA 12.x PyTorch; adding --disable-cuda-malloc for stability."
+              COMFY_ARGS+=("--disable-cuda-malloc")
+            fi
+            ;;
+        esac
+      ''}
+
       ${lib.optionalString useXpu ''
         # =====================================================================
         # Intel XPU (oneAPI / SYCL) runtime setup


### PR DESCRIPTION
## Summary

- Detect NVIDIA Blackwell / RTX 50-series GPUs in the CUDA launcher path
- Automatically add `--disable-cuda-malloc` for the current CUDA 12.x PyTorch wheel stack unless the user already set allocator flags
- Preserve user overrides via `extraArgs = [ "--cuda-malloc" ]` or `extraArgs = [ "--disable-cuda-malloc" ]`

## Context

This addresses the crash pattern reported in issue #61, where an RTX 5080 system restarts the ComfyUI service during generation after ComfyUI selects `cudaMallocAsync` with the CUDA 12.8 PyTorch wheel stack.

The PR intentionally references issue #61 for tracking, but does not close it automatically so the reporter can confirm the fix on affected hardware.

## Validation

- `nix fmt nix/packages.nix`
- `nix eval --raw .#packages.x86_64-linux.cuda.drvPath`
- `nix build --dry-run .#packages.x86_64-linux.cuda`
- `git diff --cached --check`
- Codex peer review: no findings
