### PR TITLE
refactor: avoid deprecated `xorg` package prefix

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -258,21 +258,21 @@ let
       pkgs.glib
       pkgs.libGL
       # X11 / XCB runtime libs (fixes: libxcb.so.1 not found)
-      pkgs.xorg.libxcb
-      pkgs.xorg.libX11
-      pkgs.xorg.libXext
-      pkgs.xorg.libXrender
-      pkgs.xorg.libXfixes
-      pkgs.xorg.libXi
-      pkgs.xorg.libXrandr
-      pkgs.xorg.libXcursor
-      pkgs.xorg.libXcomposite
-      pkgs.xorg.libXdamage
-      pkgs.xorg.libXau
-      pkgs.xorg.libXdmcp
-      pkgs.xorg.libSM
-      pkgs.xorg.libICE
+      pkgs.libice
+      pkgs.libsm
+      pkgs.libx11
+      pkgs.libxau
+      pkgs.libxcb
+      pkgs.libxcomposite
+      pkgs.libxcursor
+      pkgs.libxdamage
+      pkgs.libxdmcp
+      pkgs.libxext
+      pkgs.libxfixes
+      pkgs.libxi
       pkgs.libxkbcommon
+      pkgs.libxrandr
+      pkgs.libxrender
     ]
     # XPU runtime libs (Level Zero, Intel compute-runtime, OpenCL ICD) — fallback
     # when /run/opengl-driver/lib isn't available. Launcher prefers system libs.


### PR DESCRIPTION
Avoid below waring message.

```
evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXext' has been renamed to 'libxext'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXrender' has been renamed to 'libxrender'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXfixes' has been renamed to 'libxfixes'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXrandr' has been renamed to 'libxrandr'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcomposite' has been renamed to 'libxcomposite'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXdamage' has been renamed to 'libxdamage'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXau' has been renamed to 'libxau'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXdmcp' has been renamed to 'libxdmcp'
evaluation warning: The xorg package set has been deprecated, 'xorg.libSM' has been renamed to 'libsm'
evaluation warning: The xorg package set has been deprecated, 'xorg.libICE' has been renamed to 'libice'
```
