### PR TITLE
fix: use platform wheels for comfy-aimdo and comfy-kitchen native libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `comfy-aimdo` and `comfy-kitchen` now use platform wheels with their native
+  libraries (`aimdo.so`, `_C.abi3.so`) on Linux instead of the pure-Python
+  `py3-none-any` wheels, enabling DynamicVRAM support and the comfy-kitchen
+  CUDA backend (#66)
+
 ## [0.28.1] - 2026-07-17
 
 ### Changed

--- a/nix/vendored-packages.nix
+++ b/nix/vendored-packages.nix
@@ -82,6 +82,40 @@ let
       versions.vendored.comfyAngle.darwinArm64
     else
       null;
+
+  # Select a platform wheel (with native libs) when one exists, otherwise the
+  # pure-Python any-wheel. Used for comfy-kitchen and comfy-aimdo (issue #66).
+  selectPlatformWheel =
+    wheels:
+    let
+      p = pkgs.stdenv.hostPlatform;
+    in
+    if p.isLinux && p.isx86_64 && wheels ? linuxX86_64 then
+      wheels.linuxX86_64
+    else if p.isLinux && p.isAarch64 && wheels ? linuxAarch64 then
+      wheels.linuxAarch64
+    else
+      wheels.any;
+
+  # Wheel with bundled native .so files: run autoPatchelf on Linux so their
+  # glibc/libstdc++ DT_NEEDED entries resolve against the Nix store. CUDA/ROCm
+  # driver libraries are dlopen'ed at runtime, not linked, so nothing further
+  # is needed here.
+  mkNativeWheel =
+    {
+      pname,
+      version,
+      url,
+      hash,
+    }:
+    python.pkgs.buildPythonPackage {
+      inherit pname version;
+      format = "wheel";
+      src = pkgs.fetchurl { inherit url hash; };
+      doCheck = false;
+      nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+      buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+    };
 in
 rec {
   comfyuiFrontendPackage = mkWheel {
@@ -121,18 +155,16 @@ rec {
     hash = versions.vendored.manager.hash;
   };
 
-  comfyKitchen = mkWheel {
+  comfyKitchen = mkNativeWheel {
     pname = "comfy-kitchen";
     version = versions.vendored.comfyKitchen.version;
-    url = versions.vendored.comfyKitchen.url;
-    hash = versions.vendored.comfyKitchen.hash;
+    inherit (selectPlatformWheel versions.vendored.comfyKitchen) url hash;
   };
 
-  comfyAimdo = mkWheel {
+  comfyAimdo = mkNativeWheel {
     pname = "comfy-aimdo";
     version = versions.vendored.comfyAimdo.version;
-    url = versions.vendored.comfyAimdo.url;
-    hash = versions.vendored.comfyAimdo.hash;
+    inherit (selectPlatformWheel versions.vendored.comfyAimdo) url hash;
   };
 
   # null on platforms without an upstream wheel (e.g. x86_64-darwin)

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -79,11 +79,26 @@
       hash = "sha256-mwMx5bhEg7QGJgSAuSrZHb2Ec8rm4iYhJ+jBFXfOBHM=";
     };
 
-    # New ComfyUI core deps (not in nixpkgs)
+    # New ComfyUI core deps (not in nixpkgs).
+    # comfy-kitchen and comfy-aimdo ship platform wheels with native libraries
+    # (kitchen: backends/cuda/_C.abi3.so, aimdo: aimdo.so/aimdo_rocm.so). The
+    # py3-none-any wheels are pure-Python and silently disable those features
+    # (issue #66), so prefer the platform wheels where they exist and keep the
+    # any-wheel as the macOS fallback.
     comfyKitchen = {
       version = "0.2.20";
-      url = "https://files.pythonhosted.org/packages/0a/2d/0d7fac23b4284e3fa630accea21e72855f98722c24645c8cf13e3f2ddc92/comfy_kitchen-0.2.20-py3-none-any.whl";
-      hash = "sha256-rjpD97bYO84ADxfICehKVSGxyUH3UMYwI7X6HddogT8=";
+      any = {
+        url = "https://files.pythonhosted.org/packages/0a/2d/0d7fac23b4284e3fa630accea21e72855f98722c24645c8cf13e3f2ddc92/comfy_kitchen-0.2.20-py3-none-any.whl";
+        hash = "sha256-rjpD97bYO84ADxfICehKVSGxyUH3UMYwI7X6HddogT8=";
+      };
+      linuxX86_64 = {
+        url = "https://files.pythonhosted.org/packages/ff/3b/7572c2798037b9a8874e247f439cf5c3a101ee8f508fb069ad2b628ab9ed/comfy_kitchen-0.2.20-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl";
+        hash = "sha256-2e5Rd0ly4T9dIKEGejNO4mSOTn3Eqnvv4QUI6yeA9/A=";
+      };
+      linuxAarch64 = {
+        url = "https://files.pythonhosted.org/packages/8d/f5/b120e5595c48a5b8eecaae8da7ee000ee3fb622a099df2907782d9a4ef65/comfy_kitchen-0.2.20-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl";
+        hash = "sha256-XbET0N4udLmQNaSjxgIVY7JUZw0CfTwxWAJlrETIQtc=";
+      };
     };
 
     # ANGLE libraries for the GLSL shader nodes (comfy_extras/nodes_glsl.py).
@@ -107,8 +122,18 @@
 
     comfyAimdo = {
       version = "0.4.10";
-      url = "https://files.pythonhosted.org/packages/68/f4/9fc884854191a0d347e3b5bb185d68ea8099228ccb5b3116dd8aa43839e5/comfy_aimdo-0.4.10-py3-none-any.whl";
-      hash = "sha256-oG3rgljMbDPvhHO0v7bFu+EWdviAGbqoQdtiNf88m5A=";
+      any = {
+        url = "https://files.pythonhosted.org/packages/68/f4/9fc884854191a0d347e3b5bb185d68ea8099228ccb5b3116dd8aa43839e5/comfy_aimdo-0.4.10-py3-none-any.whl";
+        hash = "sha256-oG3rgljMbDPvhHO0v7bFu+EWdviAGbqoQdtiNf88m5A=";
+      };
+      linuxX86_64 = {
+        url = "https://files.pythonhosted.org/packages/3e/63/29035f15a32c1e31723585c452c7416d6c3c00f92469e2a923a35500df49/comfy_aimdo-0.4.10-cp39-abi3-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl";
+        hash = "sha256-/64FGajDd1HhCX6CdaNFCluL7prrF5tdoMAPy1eizF8=";
+      };
+      linuxAarch64 = {
+        url = "https://files.pythonhosted.org/packages/e9/ab/bcda7e71dea484fe0c796df0cb65c4288c167282210597f5de1c54744f45/comfy_aimdo-0.4.10-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl";
+        hash = "sha256-r7TYXSkebMB2l135DL+oXeKOzDuDATLQcWpnzXiQ3kk=";
+      };
     };
 
     # UI deps some custom nodes expect


### PR DESCRIPTION
Fixes #66.

## Problem

Both `comfy-aimdo` and `comfy-kitchen` were vendored as `py3-none-any` wheels, which are pure-Python and lack the native libraries:

- `comfy_aimdo/aimdo.so` (+ `aimdo_rocm.so`) — without it, `ctypes.CDLL` fails in `comfy_aimdo/control.py`, `init_devices()` returns False, and ComfyUI silently falls back to the legacy ModelPatcher: `No working comfy-aimdo install detected. DynamicVRAM support disabled.`
- `comfy_kitchen/backends/cuda/_C.abi3.so` — startup reports `Extension file not found`, disabling the kitchen CUDA backend (currently moot on cu128 torch, but will matter when torch moves to cu130)

## Fix

- Pin the platform wheels on Linux (`cp39-abi3` manylinux for aimdo, `cp312-abi3` manylinux for kitchen; both x86_64 + aarch64), keeping the `py3-none-any` wheel as the macOS fallback — upstream publishes no macOS wheels for these
- New `mkNativeWheel` helper runs `autoPatchelfHook` over the bundled `.so` files on Linux. Their DT_NEEDED entries are only glibc/libstdc++ (CUDA/ROCm driver libs are dlopen'ed at runtime), so `stdenv.cc.cc.lib` is the only extra buildInput needed

## Verification

Startup log on this repo's CUDA build, RTX 4090:

```
aimdo: control.c:247:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 4090 (VRAM: 24077 MB)
DynamicVRAM support detected and enabled
comfy-aimdo version: 0.4.10
Found comfy_kitchen backend cuda: {'available': True, ...}
```

(kitchen's CUDA backend still shows `disabled: True` on cu128 torch — upstream gates it on cu130+, exactly as noted in the issue.)

- [x] `nix build` (CPU) and `nix build .#cuda` both succeed
- [x] `aimdo.so` and `_C.abi3.so` load via ctypes from the built env
- [x] ruff/pyright/nixfmt/shellcheck/pytest checks pass