### PR TITLE
fix(model_downloader): resolve model directories dynamically from folder_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   libraries (`aimdo.so`, `_C.abi3.so`) on Linux instead of the pure-Python
   `py3-none-any` wheels, enabling DynamicVRAM support and the comfy-kitchen
   CUDA backend (#66)
+- model_downloader now resolves model directories dynamically from ComfyUI's
+  `folder_paths` via a new `/model-downloader/folders` endpoint instead of a
+  stale hardcoded list, so models for newer folder types (e.g.
+  `latent_upscale_models`) no longer land in `checkpoints/` (#65)
 
 ## [0.28.1] - 2026-07-17
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -374,7 +374,7 @@ let
             # Create directory structure (idempotent)
             mkdir -p "$BASE_DIR"/{models,output,input,user,custom_nodes,temp,web}
             mkdir -p "$BASE_DIR/web/extensions"
-            mkdir -p "$BASE_DIR/models"/{checkpoints,loras,vae,controlnet,embeddings,upscale_models,clip,clip_vision,diffusion_models,text_encoders,unet,configs,diffusers,vae_approx,gligen,hypernetworks,photomaker,style_models,classifiers,t2i_adapter}
+            mkdir -p "$BASE_DIR/models"/{checkpoints,loras,vae,controlnet,embeddings,upscale_models,clip,clip_vision,diffusion_models,text_encoders,unet,configs,diffusers,vae_approx,gligen,hypernetworks,photomaker,style_models,classifiers,t2i_adapter,audio_encoders,background_removal,detection,frame_interpolation,geometry_estimation,latent_upscale_models,model_patches,optical_flow}
 
             # Expose base dir for custom nodes that need a writable location (Nix store is read-only)
             export COMFYUI_BASE_DIR="$BASE_DIR"

--- a/src/custom_nodes/model_downloader/__init__.py
+++ b/src/custom_nodes/model_downloader/__init__.py
@@ -40,6 +40,7 @@ _download_model_handler: DownloadHandler | None = None
 _get_download_progress_handler: DownloadHandler | None = None
 _list_downloads_handler: DownloadHandler | None = None
 _resolve_folder_handler: DownloadHandler | None = None
+_list_folders_handler: DownloadHandler | None = None
 
 try:
     spec = importlib.util.spec_from_file_location(
@@ -57,6 +58,7 @@ try:
     _get_download_progress_handler = model_downloader_patch.get_download_progress
     _list_downloads_handler = model_downloader_patch.list_downloads
     _resolve_folder_handler = model_downloader_patch.resolve_folder
+    _list_folders_handler = model_downloader_patch.list_folders
 
     logger.info("Successfully imported model downloader module")
 except ImportError:
@@ -99,6 +101,15 @@ async def resolve_folder(request: Any) -> Any:
     return web.json_response({"success": False, "error": "Model downloader not available"})
 
 
+async def list_folders(request: Any) -> Any:
+    """List model folders handler - delegates to loaded module or returns error."""
+    if _list_folders_handler is not None:
+        return await _list_folders_handler(request)
+    from aiohttp import web
+
+    return web.json_response({"success": False, "error": "Model downloader not available"})
+
+
 def setup_js_api(app: Any, *args: Any, **kwargs: Any) -> Any:
     """
     Define API handler for ComfyUI extension system.
@@ -125,6 +136,7 @@ def setup_js_api(app: Any, *args: Any, **kwargs: Any) -> Any:
         "/model-downloader/progress/",
         "/model-downloader/downloads",
         "/model-downloader/resolve-folder/",
+        "/model-downloader/folders",
     ]
 
     # Check if any of our routes already exist
@@ -152,6 +164,10 @@ def setup_js_api(app: Any, *args: Any, **kwargs: Any) -> Any:
     if "/model-downloader/resolve-folder/" not in existing_routes:
         app.router.add_get("/model-downloader/resolve-folder/{filename}", resolve_folder)
         logger.info("Registered /model-downloader/resolve-folder endpoint")
+
+    if "/model-downloader/folders" not in existing_routes:
+        app.router.add_get("/model-downloader/folders", list_folders)
+        logger.info("Registered /model-downloader/folders endpoint")
 
     logger.info("Model downloader API endpoints registered successfully")
     return app

--- a/src/custom_nodes/model_downloader/js/model_downloader_core.js
+++ b/src/custom_nodes/model_downloader/js/model_downloader_core.js
@@ -170,14 +170,37 @@
   }
 
   // ── Directory detection ───────────────────────────────────────────────
-  // ComfyUI folder_paths directory names that map to model types
+  // ComfyUI folder_paths directory names that map to model types.
+  // Static fallback only — refreshKnownDirs() replaces this knowledge with the
+  // server's live folder_paths list so new folder types are picked up
+  // automatically (see /model-downloader/folders).
   const KNOWN_DIRS = new Set([
-    'checkpoints', 'classifiers', 'clip', 'clip_vision', 'configs',
-    'controlnet', 'diffusers', 'diffusion_models', 'embeddings', 'gligen',
-    'hypernetworks', 'loras', 'mmdets', 'photomaker', 'style_models',
-    't2i_adapter', 'text_encoders', 'unet', 'upscale_models', 'vae',
-    'vae_approx'
+    'audio_encoders', 'background_removal', 'checkpoints', 'classifiers',
+    'clip', 'clip_vision', 'configs', 'controlnet', 'detection', 'diffusers',
+    'diffusion_models', 'embeddings', 'frame_interpolation',
+    'geometry_estimation', 'gligen', 'hypernetworks', 'latent_upscale_models',
+    'loras', 'mmdets', 'model_patches', 'optical_flow', 'photomaker',
+    'style_models', 't2i_adapter', 'text_encoders', 'unet', 'upscale_models',
+    'vae', 'vae_approx'
   ]);
+
+  // Merge the authoritative folder list from the backend into KNOWN_DIRS so
+  // directory detection recognizes folder types added by newer ComfyUI
+  // versions without requiring an update to the hardcoded fallback above.
+  async function refreshKnownDirs() {
+    try {
+      const resp = await fetch('/model-downloader/folders');
+      if (resp.ok) {
+        const data = await resp.json();
+        if (data.success && Array.isArray(data.folders)) {
+          for (const name of data.folders) KNOWN_DIRS.add(name);
+          console.log('[MODEL_DOWNLOADER] Loaded', data.folders.length, 'folder names from backend');
+        }
+      }
+    } catch (e) {
+      console.warn('[MODEL_DOWNLOADER] Failed to fetch folder list, using built-in defaults:', e);
+    }
+  }
 
   // Proactive cache: filename → directory, populated by observing the Missing Models panel
   const dirCache = {};
@@ -467,6 +490,7 @@
   function initialize() {
     interceptBrowserDownloads();
     observeMissingModelsPanel();
+    refreshKnownDirs();
     return true;
   }
 
@@ -474,7 +498,8 @@
   window.modelDownloaderCore = {
     isTrustedDomain, downloadModelWithBackend, interceptBrowserDownloads,
     initialize, handleMessageEvent, getOrCreateRow, updateRow,
-    scanMissingModelsPanel, detectDirectory, resolveDirectoryFromBackend, dirCache
+    scanMissingModelsPanel, detectDirectory, resolveDirectoryFromBackend,
+    refreshKnownDirs, dirCache
   };
 
   if (!window.modelDownloader) {

--- a/src/custom_nodes/model_downloader/model_downloader_patch.py
+++ b/src/custom_nodes/model_downloader/model_downloader_patch.py
@@ -651,6 +651,23 @@ async def resolve_folder(request: web.Request) -> web.Response:
     return web.json_response({"success": False, "error": f"File not found: {filename}"})
 
 
+async def list_folders(request: web.Request) -> web.Response:
+    """Return the model folder names registered with ComfyUI.
+
+    Lets the frontend build its directory list dynamically instead of relying
+    on a hardcoded set that goes stale as ComfyUI adds new folder types
+    (e.g. latent_upscale_models in v0.25+). custom_nodes is excluded since it
+    is not a model destination.
+    """
+    try:
+        folders = sorted(
+            name for name in folder_paths.folder_names_and_paths if name != "custom_nodes"
+        )
+        return web.json_response({"success": True, "folders": folders})
+    except (TypeError, ValueError) as e:
+        return web.json_response({"success": False, "error": str(e)})
+
+
 def setup_js_api(app: Any, *args: Any, **kwargs: Any) -> Any:
     """
     Compatibility function for ComfyUI extension system.

--- a/src/custom_nodes/model_downloader/test_model_downloader.py
+++ b/src/custom_nodes/model_downloader/test_model_downloader.py
@@ -464,3 +464,22 @@ class TestSendDownloadUpdate:
     def test_ignores_missing_download(self):
         # Should not raise
         asyncio.run(mdp.send_download_update("nonexistent"))
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_folders
+# ---------------------------------------------------------------------------
+
+
+class TestListFolders:
+    def test_returns_sorted_folders_excluding_custom_nodes(self):
+        mdp.folder_paths.folder_names_and_paths = {
+            "loras": ([], set()),
+            "custom_nodes": ([], set()),
+            "checkpoints": ([], set()),
+            "latent_upscale_models": ([], set()),
+        }
+        response = asyncio.run(mdp.list_folders(MagicMock()))
+        data = json.loads(response.body)
+        assert data["success"] is True
+        assert data["folders"] == ["checkpoints", "latent_upscale_models", "loras"]

--- a/src/custom_nodes/model_downloader/test_model_downloader.py
+++ b/src/custom_nodes/model_downloader/test_model_downloader.py
@@ -480,6 +480,6 @@ class TestListFolders:
             "latent_upscale_models": ([], set()),
         }
         response = asyncio.run(mdp.list_folders(MagicMock()))
-        data = json.loads(response.body)
+        data = json.loads(response.body)  # type: ignore[arg-type]
         assert data["success"] is True
         assert data["folders"] == ["checkpoints", "latent_upscale_models", "loras"]


### PR DESCRIPTION
Fixes #65.

## Problem

The frontend's hardcoded `KNOWN_DIRS` set predates the model folder types ComfyUI has added since (`latent_upscale_models`, `model_patches`, `audio_encoders`, `background_removal`, `detection`, `frame_interpolation`, `geometry_estimation`, `optical_flow`). For workflow templates referencing those folders (e.g. `video_ltx2_3_i2v`'s spatial upscaler), every strategy in `detectDirectory()` failed and the final fallback dumped the model into `checkpoints/` — leaving the loader dropdown empty while "Download all" reported the file as already existing.

## Fix

Implements the "proper fix" suggested in the issue:

- **Backend**: new `GET /model-downloader/folders` endpoint returning the live `folder_paths.folder_names_and_paths` keys (minus `custom_nodes`), so the frontend always sees exactly what the running ComfyUI accepts
- **Frontend**: `refreshKnownDirs()` fetches that list at initialization and merges it into `KNOWN_DIRS`; the hardcoded set remains as a fallback and has been refreshed with all current folder types
- **Launcher**: pre-creates the new model subdirectories alongside the existing ones
- **Tests**: unit test for the new endpoint (sorted output, `custom_nodes` excluded)

## Verification

- [x] Runtime test against the built package: `/model-downloader/folders` returns 43 folders including `latent_upscale_models`; `/model-downloader/resolve-folder/*` unchanged
- [x] `pytest`: 35/35 pass
- [x] ruff/pyright/nixfmt/shellcheck checks pass
- [x] `nix build` succeeds