### PR TITLE
feat(module): support declarative Python dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,57 @@ jobs:
           nix build .#checks.x86_64-linux.shellcheck --print-build-logs
           nix build .#checks.x86_64-linux.pytest --print-build-logs
 
+  # Realize the extended runtime for every backend so PRs cannot replace the
+  # backend-specific Torch/NumPy stack or ship dependencies that fail to import.
+  extra-python-packages:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - extra-python-packages
+          - extra-python-packages-cuda
+          - extra-python-packages-rocm
+          - extra-python-packages-xpu
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
+          docker system prune -af || true
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: comfyui
+          pushFilter: "-"
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: nix-community
+          pushFilter: "-"
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: cuda-maintainers
+          pushFilter: "-"
+
+      - name: Build ${{ matrix.check }}
+        run: |
+          nix build .#checks.x86_64-linux.${{ matrix.check }} \
+            --print-build-logs --max-jobs 1 --cores 2
+
   # Full nix flake check (includes package build) — only on main/tags
   check:
     if: github.event_name != 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `services.comfyui.extraPythonPackages` for reproducibly including
+  custom-node dependencies in the selected CPU, CUDA, ROCm, or XPU Python
+  runtime without replacing pinned core packages (#58)
+
 ## [0.30.0] - 2026-08-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ nix profile add github:utensils/comfyui-nix#xpu
 | `openFirewall`  | `false`              | Open the port in the firewall                    |
 | `extraArgs`     | `[]`                 | Additional CLI arguments                         |
 | `environment`   | `{}`                 | Environment variables for the service            |
+| `extraPythonPackages` | `null`          | Extra declarative Python dependencies             |
 | `customNodes`   | `{}`                 | Declarative custom nodes (see below)             |
 | `requiresMounts`| `[]`                 | Mount units to wait for before starting          |
 
@@ -484,6 +485,40 @@ services.comfyui = {
 ```
 
 Nodes are symlinked at service start. This is the pure Nix approach - fully reproducible and version-pinned.
+
+Custom nodes with additional Python dependencies can extend the selected
+CPU/CUDA/ROCm/XPU runtime declaratively:
+
+```nix
+services.comfyui = {
+  customNodes.ComfyUI-Usgromana = pkgs.fetchFromGitHub {
+    owner = "DayMan84";
+    repo = "ComfyUI-Usgromana";
+    rev = "2.0.0";
+    hash = "sha256-vzb0GX3hYpER4Xqmc7bkbx5AiMDgWRyIcLapJefD71Q=";
+  };
+
+  extraPythonPackages = ps: with ps; [
+    bcrypt
+    pyjwt
+    bleach
+  ];
+};
+```
+
+`extraPythonPackages` uses the same overridden Python package set as ComfyUI,
+so GPU-specific packages such as Torch are not replaced by dependencies from a
+separate environment. Requirements files are not installed automatically: list
+each required nixpkgs package explicitly so the result remains reproducible.
+The option cannot be combined with a custom `services.comfyui.package`; include
+the dependencies directly when supplying a fully custom package.
+
+Declarative node sources are read-only. Nodes that write databases, logs, or
+configuration beneath their own source directory must support a separate
+writable data directory or be patched accordingly. Usgromana 2.0.0 writes state
+beneath its extension directory, so its Python dependencies can be declared as
+above, but the node still needs writable-state handling before it is suitable
+for a fully declarative deployment.
 
 ## Docker / Podman
 

--- a/flake.nix
+++ b/flake.nix
@@ -268,9 +268,14 @@
           formatter = pkgs.nixfmt-rfc-style;
 
           checks = import ./nix/checks.nix {
-            inherit pkgs source;
+            inherit
+              nixpkgs
+              pkgs
+              source
+              ;
             packages = self'.packages;
             pythonRuntime = nativePackages.pythonRuntime;
+            nixosModule = self.nixosModules.default;
           };
         };
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,9 +1,139 @@
 {
+  nixpkgs,
   pkgs,
   source,
   packages,
   pythonRuntime,
+  nixosModule,
 }:
+let
+  emptyExtendedPackage = packages.default.withExtraPythonPackages (_: [ ]);
+  duplicateCorePackage = packages.default.withExtraPythonPackages (ps: [ ps.numpy ]);
+  extendedPackage = packages.default.withExtraPythonPackages (ps: [
+    ps.bcrypt
+    ps.pyjwt
+    ps.bleach
+  ]);
+  chainedPackage =
+    (packages.default.withExtraPythonPackages (ps: [ ps.bcrypt ])).withExtraPythonPackages
+      (ps: [
+        ps.pyjwt
+        ps.bleach
+      ]);
+  backendPackages = [
+    packages.default
+  ]
+  ++ pkgs.lib.optional (packages ? cuda) packages.cuda
+  ++ pkgs.lib.optional (packages ? rocm) packages.rocm
+  ++ pkgs.lib.optional (packages ? xpu) packages.xpu;
+  backendPackagesPreserved = pkgs.lib.all (
+    package:
+    let
+      extended = package.withExtraPythonPackages (ps: [ ps.bcrypt ]);
+    in
+    package.pythonRuntime.pkgs.torch.outPath == extended.pythonRuntime.pkgs.torch.outPath
+    && package.pythonRuntime.pkgs.numpy.outPath == extended.pythonRuntime.pkgs.numpy.outPath
+  ) backendPackages;
+  evalModule =
+    serviceConfig:
+    nixpkgs.lib.nixosSystem {
+      system = pkgs.stdenv.hostPlatform.system;
+      modules = [
+        nixosModule
+        {
+          system.stateVersion = "26.05";
+          services.comfyui = {
+            enable = true;
+          }
+          // serviceConfig;
+        }
+      ];
+    };
+  defaultModuleSystem = evalModule { };
+  moduleSystem = evalModule {
+    extraPythonPackages = ps: [
+      ps.bcrypt
+      ps.pyjwt
+      ps.bleach
+    ];
+  };
+  unsupportedPackageSystem = evalModule {
+    package = packages.default.overrideAttrs (_: {
+      pname = "custom-comfy-ui";
+    });
+    extraPythonPackages = ps: [ ps.bcrypt ];
+  };
+  unsupportedPackageRejected = pkgs.lib.any (
+    assertion:
+    !assertion.assertion && pkgs.lib.hasInfix "cannot be combined with a custom" assertion.message
+  ) unsupportedPackageSystem.config.assertions;
+  backendModuleSpecs = [
+    {
+      gpuSupport = "none";
+      package = packages.default;
+    }
+  ]
+  ++ pkgs.lib.optional (packages ? cuda) {
+    gpuSupport = "cuda";
+    package = packages.cuda;
+  }
+  ++ pkgs.lib.optional (packages ? rocm) {
+    gpuSupport = "rocm";
+    package = packages.rocm;
+  }
+  ++ pkgs.lib.optional (packages ? xpu) {
+    gpuSupport = "xpu";
+    package = packages.xpu;
+  };
+  backendModulesPreserved = pkgs.lib.all (
+    spec:
+    let
+      system = evalModule {
+        inherit (spec) gpuSupport;
+        extraPythonPackages = ps: [ ps.bcrypt ];
+      };
+      expected = spec.package.withExtraPythonPackages (ps: [ ps.bcrypt ]);
+      execStart = system.config.systemd.services.comfyui.serviceConfig.ExecStart;
+    in
+    pkgs.lib.hasPrefix expected.outPath execStart
+  ) backendModuleSpecs;
+  defaultModuleExecStart =
+    defaultModuleSystem.config.systemd.services.comfyui.serviceConfig.ExecStart;
+  moduleExecStart = moduleSystem.config.systemd.services.comfyui.serviceConfig.ExecStart;
+  mkExtraPythonPackagesCheck =
+    name: package:
+    let
+      extended = package.withExtraPythonPackages (ps: [
+        ps.bcrypt
+        ps.pyjwt
+        ps.bleach
+      ]);
+    in
+    assert package.pythonRuntime.pkgs.torch.outPath == extended.pythonRuntime.pkgs.torch.outPath;
+    assert package.pythonRuntime.pkgs.numpy.outPath == extended.pythonRuntime.pkgs.numpy.outPath;
+    pkgs.runCommand name
+      {
+        nativeBuildInputs = [ extended.pythonRuntime ];
+      }
+      ''
+        ${extended.pythonRuntime}/bin/python - <<'PY'
+        import aiohttp
+        import bcrypt
+        import bleach
+        import jwt
+        import numpy
+        import torch
+
+        assert aiohttp.__version__
+        assert bcrypt.__version__
+        assert bleach.__version__
+        assert jwt.__version__
+        assert numpy.__version__
+        assert torch.__version__
+        PY
+        touch $out
+      '';
+in
 {
   package = packages.default;
 }
@@ -15,7 +145,50 @@
 // pkgs.lib.optionalAttrs (packages ? xpu) {
   package-xpu = packages.xpu;
 }
+// pkgs.lib.optionalAttrs (packages ? cuda) {
+  extra-python-packages-cuda = mkExtraPythonPackagesCheck "extra-python-packages-cuda" packages.cuda;
+}
+// pkgs.lib.optionalAttrs (packages ? rocm) {
+  extra-python-packages-rocm = mkExtraPythonPackagesCheck "extra-python-packages-rocm" packages.rocm;
+}
+// pkgs.lib.optionalAttrs (packages ? xpu) {
+  extra-python-packages-xpu = mkExtraPythonPackagesCheck "extra-python-packages-xpu" packages.xpu;
+}
 // {
+
+  extra-python-packages =
+    assert emptyExtendedPackage.outPath == packages.default.outPath;
+    assert emptyExtendedPackage.pythonRuntime.outPath == pythonRuntime.outPath;
+    assert duplicateCorePackage.pythonRuntime.outPath == pythonRuntime.outPath;
+    assert backendPackagesPreserved;
+    assert pkgs.lib.hasPrefix packages.default.outPath defaultModuleExecStart;
+    assert pkgs.lib.hasPrefix extendedPackage.outPath moduleExecStart;
+    assert unsupportedPackageRejected;
+    assert backendModulesPreserved;
+    pkgs.runCommand "extra-python-packages"
+      {
+        nativeBuildInputs = [ chainedPackage.pythonRuntime ];
+      }
+      ''
+        ${chainedPackage.pythonRuntime}/bin/python - <<'PY'
+        import aiohttp
+        import bcrypt
+        import bleach
+        import jwt
+        import numpy
+        import torch
+
+        assert aiohttp.__version__
+        assert bcrypt.__version__
+        assert bleach.__version__
+        assert jwt.__version__
+        assert numpy.__version__
+        assert torch.__version__
+        PY
+        touch $out
+      '';
+
+  extra-python-packages-runtime = mkExtraPythonPackagesCheck "extra-python-packages-runtime" packages.default;
 
   pytest =
     let

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -23,6 +23,13 @@ let
       pkgs.comfy-ui-xpu
     else
       pkgs.comfy-ui;
+  effectivePackage =
+    if cfg.extraPythonPackages == null then
+      cfg.package
+    else if cfg.package.outPath == resolvePackage.outPath then
+      resolvePackage.withExtraPythonPackages cfg.extraPythonPackages
+    else
+      cfg.package;
   args = [
     "--listen"
     cfg.listenAddress
@@ -35,7 +42,7 @@ let
   ++ cfg.extraArgs;
   env = cfg.environment;
   escapedArgs = lib.concatStringsSep " " (map lib.escapeShellArg args);
-  execStart = "${cfg.package}/bin/comfy-ui ${escapedArgs}";
+  execStart = "${effectivePackage}/bin/comfy-ui ${escapedArgs}";
 
   # User/group creation: only create if createUser is true AND the user doesn't
   # already exist in the system (i.e., not a pre-existing user like "nobody")
@@ -251,6 +258,31 @@ in
       description = "Environment variables for the ComfyUI service.";
     };
 
+    extraPythonPackages = lib.mkOption {
+      type = lib.types.nullOr (lib.types.functionTo (lib.types.listOf lib.types.package));
+      default = null;
+      defaultText = lib.literalExpression "null";
+      example = lib.literalExpression ''
+        ps: with ps; [
+          bcrypt
+          pyjwt
+          bleach
+        ]
+      '';
+      description = ''
+        Additional Python packages to include in ComfyUI's packaged runtime.
+        The function receives the same backend-specific Python package set used
+        by the selected CPU, CUDA, ROCm, or XPU package, so pinned core packages
+        such as Torch and NumPy remain consistent.
+
+        Packages are installed declaratively and must be available in nixpkgs.
+        This option does not run custom-node requirements files automatically.
+
+        This option cannot be combined with a custom services.comfyui.package.
+        Package overrides must include their Python dependencies directly.
+      '';
+    };
+
     customNodes = lib.mkOption {
       type = lib.types.attrsOf lib.types.package;
       default = { };
@@ -263,9 +295,9 @@ in
         This is the pure Nix way to manage custom nodes - fully reproducible
         and version-pinned.
 
-        Note: Custom nodes with Python dependencies beyond ComfyUI's base
-        environment may require additional configuration. For complex nodes,
-        consider creating a custom derivation that bundles dependencies.
+        Add Python dependencies beyond ComfyUI's base environment with
+        services.comfyui.extraPythonPackages. Nodes that write files beneath
+        their own source directory still require a separate writable data path.
       '';
       example = lib.literalExpression ''
         {
@@ -301,6 +333,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.extraPythonPackages == null || cfg.package.outPath == resolvePackage.outPath;
+        message = ''
+          services.comfyui.extraPythonPackages cannot be combined with a custom
+          services.comfyui.package because rebuilding the Python runtime could
+          silently discard package overrides.
+        '';
+      }
+    ];
+
     nixpkgs.config = lib.mkIf (cfg.cudaCapabilities != null) {
       cudaCapabilities = cfg.cudaCapabilities;
     };

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -4,6 +4,7 @@
   versions,
   pythonOverrides,
   gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
+  extraPythonPackages ? (_: [ ]),
 }:
 let
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
@@ -303,7 +304,7 @@ let
         # comfy-angle (GLSL shader nodes): no wheel on x86_64-darwin
         ++ lib.optionals (vendored.comfyAngle != null) [ vendored.comfyAngle ];
     in
-    base ++ extras ++ optionals
+    base ++ extras ++ optionals ++ extraPythonPackages ps
   );
 
   frontendRoot = "${pythonRuntime}/${python.sitePackages}/comfyui_frontend_package/static";
@@ -795,6 +796,18 @@ let
         frontendRoot
         ;
       version = versions.comfyui.version;
+      withExtraPythonPackages =
+        packages:
+        (import ./packages.nix {
+          inherit
+            pkgs
+            lib
+            versions
+            pythonOverrides
+            gpuSupport
+            ;
+          extraPythonPackages = ps: extraPythonPackages ps ++ packages ps;
+        }).default;
       # Expose heavy packages for Docker layer optimization
       # These are added to contents separately so buildLayeredImage creates distinct layers
       heavyDeps = [


### PR DESCRIPTION
## Summary

- add a composable `withExtraPythonPackages` package API
- add `services.comfyui.extraPythonPackages` for declarative custom-node dependencies
- preserve the selected CPU, CUDA, ROCm, or XPU Python/Torch runtime
- reject ambiguous mixing with a custom `services.comfyui.package`
- document the Usgromana setup and writable-state limitation
- add composition, module, import, and backend regression checks plus PR CI coverage

## Validation

- `nix flake check`
- `nix flake check --all-systems --no-build`
- Linux CPU realization and imports on the remote builder
- default package output identity checked against `origin/main`
- staged diff and GitHub Actions YAML validation
- two independent agent review passes with no remaining actionable findings

The CUDA, ROCm, and XPU realization/import checks are included in the PR CI matrix. A local remote-builder run constructed their large dependency closures but was interrupted after an extended transfer/fixup phase rather than reported as complete.

Closes #58