### PR TITLE
fix: update bundled rgthree-comfy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Updated the bundled rgthree-comfy extension so its frontend-only nodes load
+  with ComfyUI v0.30.0 instead of being replaced by the incompatible 2023
+  v1.0.0 bundle (#76)
+
 ## [0.30.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ A non-blocking async download node with WebSocket progress updates. Download mod
 
 ### rgthree-comfy
 
-[rgthree-comfy] (v1.0.0) - Quality of life nodes. _License: MIT_
+[rgthree-comfy] (v1.0.2607232129) - Quality of life nodes. _License: MIT_
 
 - **Reroute nodes** - Better workflow organization
 - **Context nodes** - Pass multiple values through a single connection

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -144,6 +144,10 @@ in
         nativeBuildInputs = [ pythonRuntime ];
       }
       ''
+        test -f ${packages.default.customNodes.rgthree-comfy}/web/comfyui/label.js
+        grep -q 'name: "rgthree.Label"' \
+          ${packages.default.customNodes.rgthree-comfy}/web/comfyui/label.js
+
         PYTHONPATH=${packages.default.comfyuiSrc} ${pythonRuntime}/bin/python - <<'PY'
         import importlib.util
         import sys

--- a/nix/custom-nodes.nix
+++ b/nix/custom-nodes.nix
@@ -71,26 +71,6 @@ let
       hash = versions.customNodes.rgthree-comfy.hash;
     };
 
-    # Convert CRLF to LF and patch __init__.py to use WEB_DIRECTORY
-    # instead of shutil.copytree (which fails with read-only Nix store)
-    postPatch = ''
-      # Convert line endings
-      sed -i 's/\r$//' __init__.py py/power_prompt.py
-
-      # Remove shutil import and PromptServer import
-      sed -i '/^import shutil$/d' __init__.py
-      sed -i '/^from server import PromptServer$/d' __init__.py
-
-      # Replace the copytree logic with WEB_DIRECTORY
-      sed -i '/^DIR_WEB_JS=/,/^shutil.copytree/d' __init__.py
-      sed -i '/^DIR_PY=/a # Use ComfyUI'"'"'s WEB_DIRECTORY for serving web assets (Nix-compatible)' __init__.py
-      sed -i '/WEB_DIRECTORY for serving/a WEB_DIRECTORY = "./js"' __init__.py
-
-      # Fix SyntaxWarning: invalid escape sequence in power_prompt.py
-      # Change pattern='<lora:...' to pattern=r'<lora:...'
-      sed -i "s/pattern='<lora:/pattern=r'<lora:/" py/power_prompt.py
-    '';
-
     dontBuild = true;
     dontConfigure = true;
 

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -398,11 +398,11 @@
     };
 
     rgthree-comfy = {
-      version = "1.0.0";
+      version = "1.0.2607232129";
       owner = "rgthree";
       repo = "rgthree-comfy";
-      rev = "v.1.0.0";
-      hash = "sha256-bzQcQ37v7ZrHDitZV6z3h/kdNbWxpLxNSvh0rSxnLss=";
+      rev = "6b76ee6f2c5a007710b5a16f97c94330d6ecc871";
+      hash = "sha256-tcgwh2xiUXyQpLuYy/X2kxMKZz1+VlLPRf7HQA3lvhk=";
     };
 
     kjnodes = {


### PR DESCRIPTION
## Summary
- update bundled rgthree-comfy from the incompatible 2023 v1.0.0 release to upstream 1.0.2607232129
- remove the obsolete Nix web-directory rewrite now that upstream declares `WEB_DIRECTORY` and ships built `web/comfyui` assets
- add a regression check for the frontend-only `Label (rgthree)` registration and refresh docs

## Validation
- `nix flake check`
- `nix build .#checks.aarch64-darwin.comfy-extras-imports --no-link`
- fresh `nix run` on ComfyUI v0.30.0 with isolated data directory
- browser UAT using the workflow attached to issue #76: rgthree progress UI and menu loaded, workflow opened, and no rgthree nodes were reported missing
- independent agent peer review: no findings

The supplied workflow still reports its expected missing `ComfyUI-DaSiWa-Nodes` pack, which is unrelated to rgthree.

Fixes #76