### PR TITLE
feat(cuda)!: upgrade the CUDA backend to 13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   NVIDIA driver 580 or newer is now required.
 
 ### Removed
-- CUDA support for Pascal and Volta GPUs.
-  CUDA builds now support Turing and newer architectures
-  because CUDA 13 no longer provides compiler or library support for pre-Turing GPUs.
-  Users of older GPUs must remain on an earlier comfyui-nix release.
+- CUDA support for Pascal and Volta GPUs, the pre-Turing architectures supported
+  by previous releases. CUDA 13 no longer provides compiler or library support
+  for pre-Turing GPUs. Pascal and Volta users must remain on an earlier
+  comfyui-nix release; Maxwell and older architectures were already unsupported.
 
 ## [0.30.2] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgraded Linux CUDA builds from PyTorch cu128 to cu130 and switched the
+  runtime toolchain and libraries from CUDA 12.8 to CUDA 13.0.
+  NVIDIA driver 580 or newer is now required.
+
+### Removed
+- CUDA support for Pascal and Volta GPUs.
+  CUDA builds now support Turing and newer architectures
+  because CUDA 13 no longer provides compiler or library support for pre-Turing GPUs.
+  Users of older GPUs must remain on an earlier comfyui-nix release.
+
 ## [0.30.2] - 2026-08-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Template input files: auto-generated in `nix/template-inputs.nix`
   - Update with: `./scripts/update-template-inputs.sh && git add nix/template-inputs.nix`
 - Python version: 3.12
-- PyTorch: macOS uses pre-built wheels (2.5.1, pinned to work around MPS bugs on macOS 26); CUDA uses pre-built wheels from pytorch.org (cu128); ROCm uses pre-built wheels from pytorch.org (rocm7.1); Intel XPU uses pre-built wheels from pytorch.org (xpu, oneAPI/SYCL — no IPEX); Linux CPU uses nixpkgs
+- PyTorch: macOS uses pre-built wheels (2.5.1, pinned to work around MPS bugs on macOS 26); CUDA uses pre-built wheels from pytorch.org (cu130); ROCm uses pre-built wheels from pytorch.org (rocm7.1); Intel XPU uses pre-built wheels from pytorch.org (xpu, oneAPI/SYCL — no IPEX); Linux CPU uses nixpkgs
 
 ## Project Architecture
 
@@ -154,7 +154,7 @@ fonts/         - Bundled fonts for nodes requiring system fonts
 ### Platform-Specific Notes
 
 - macOS: PyTorch pinned to 2.5.1 to work around MPS bugs on macOS 26 (Tahoe); browser opens via `/usr/bin/open`
-- CUDA: Pre-built wheels from pytorch.org with CUDA 12.8 runtime bundled (no separate toolkit needed); supports Pascal through Blackwell
+- CUDA: Pre-built wheels from pytorch.org with CUDA 13.0 runtime supplied by nixpkgs (no separate toolkit needed); supports Turing through Blackwell and requires NVIDIA driver 580 or newer
 - ROCm: Pre-built wheels from pytorch.org with ROCm 7.1 runtime bundled; tested on gfx1100 (7900 XTX); `/run/opengl-driver/lib` provides AMD drivers on NixOS
 - Intel XPU: Pre-built wheels from pytorch.org (oneAPI / SYCL, no IPEX); supports Arc A/B series + Core Ultra iGPUs (Meteor Lake+); untested on maintainer hardware — treat external user reports as authoritative; `/run/opengl-driver/lib` preferred, Nix-bundled `level-zero`/`intel-compute-runtime` as non-NixOS fallback
 - Linux CPU: Uses nixpkgs PyTorch; browser opens via `xdg-open`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For CUDA (Linux/NVIDIA):
 nix run github:utensils/comfyui-nix#cuda
 ```
 
-CUDA builds use pre-built PyTorch wheels from pytorch.org, so builds are fast (~2GB download) and support all GPU architectures from Pascal (GTX 1080) through Blackwell (RTX 5090) in a single package.
+CUDA builds use pre-built PyTorch wheels from pytorch.org, so builds are fast (~2GB download) and support NVIDIA GPU architectures from Turing (RTX 20 series) through Blackwell (RTX 50 series) in a single package.
 
 For ROCm (Linux/AMD):
 
@@ -69,14 +69,15 @@ CUDA builds are available for Linux with NVIDIA GPUs. The `#cuda` package uses p
 
 - **Fast builds**: Downloads ~2GB of pre-built wheels instead of compiling for hours
 - **Low memory**: No 30-60GB RAM requirement for compilation
-- **All architectures**: Supports Pascal (GTX 1080) through Blackwell (RTX 5090) in one package
-- **Bundled runtime**: CUDA 12.8 libraries included in wheels (no separate toolkit needed)
+- **Current architectures**: Supports Turing (RTX 20 series) through Blackwell (RTX 50 series) in one package
+- **Bundled runtime**: CUDA 13.0 libraries included in the package (no separate toolkit needed)
+- **Driver requirement**: NVIDIA driver 580 or newer
 
 ```bash
 nix run github:utensils/comfyui-nix#cuda
 ```
 
-This single package works on any NVIDIA GPU from the past ~8 years.
+CUDA 13 no longer supports Maxwell, Pascal, or Volta GPUs. Use an older release of comfyui-nix for those architectures.
 
 ## ROCm GPU Support
 
@@ -408,7 +409,7 @@ nix profile add github:utensils/comfyui-nix#xpu
     gpuSupport = "cuda";  # Enable NVIDIA GPU acceleration (recommended for most users)
     # gpuSupport = "rocm";  # Enable AMD GPU acceleration
     # cudaCapabilities = [ "8.9" ];  # Optional: optimize system CUDA packages for RTX 40xx
-    #   Note: Pre-built PyTorch wheels already support all GPU architectures
+    #   Note: Pre-built PyTorch wheels already include every supported GPU architecture
     enableManager = true;  # Enable the built-in ComfyUI Manager
     port = 8188;
     listenAddress = "127.0.0.1";  # Use "0.0.0.0" for network access
@@ -531,7 +532,7 @@ Pre-built images on GitHub Container Registry:
 docker run -p 8188:8188 -v "$PWD/data:/data" ghcr.io/utensils/comfyui-nix:latest
 
 # CUDA (x86_64 only, requires nvidia-container-toolkit)
-# Supports ALL GPU architectures: Pascal, Volta, Turing, Ampere, Ada, Hopper, Blackwell
+# Supports Turing, Ampere, Ada, Hopper, and Blackwell
 docker run --gpus all -p 8188:8188 -v "$PWD/data:/data" ghcr.io/utensils/comfyui-nix:latest-cuda
 
 # ROCm (x86_64 only)

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ CUDA builds are available for Linux with NVIDIA GPUs. The `#cuda` package uses p
 - **Fast builds**: Downloads ~2GB of pre-built wheels instead of compiling for hours
 - **Low memory**: No 30-60GB RAM requirement for compilation
 - **Current architectures**: Supports Turing (RTX 20 series) through Blackwell (RTX 50 series) in one package
-- **Bundled runtime**: CUDA 13.0 libraries included in the package (no separate toolkit needed)
+- **Included runtime**: CUDA 13.0 libraries provided by nixpkgs in the Nix closure (no separate toolkit needed)
 - **Driver requirement**: NVIDIA driver 580 or newer
 
 ```bash
 nix run github:utensils/comfyui-nix#cuda
 ```
 
-CUDA 13 no longer supports Maxwell, Pascal, or Volta GPUs. Use an older release of comfyui-nix for those architectures.
+CUDA 13 no longer supports pre-Turing GPUs. Pascal and Volta users must use an older comfyui-nix release; earlier architectures were already unsupported.
 
 ## ROCm GPU Support
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,8 @@
           # compiling from source. This provides:
           # - Fast builds (download ~2GB vs compile for hours)
           # - Low memory usage (no 30-60GB RAM requirement)
-          # - All GPU architectures supported (Pascal through Blackwell)
-          # - CUDA 12.8 runtime bundled in wheels
+          # - All supported GPU architectures included in one package
+          # - CUDA runtime included in the package
           # =======================================================================
 
           # =======================================================================
@@ -134,7 +134,7 @@
           linuxArm64Packages = mkComfyPackages pkgsLinuxArm64 { };
 
           nativePackages = mkComfyPackages pkgs { };
-          # CUDA uses pre-built wheels (supports all GPU architectures)
+          # CUDA uses pre-built wheels for all supported GPU architectures
           nativePackagesCuda = mkComfyPackages pkgs { gpuSupport = "cuda"; };
           nativePackagesRocm = mkComfyPackages pkgs { gpuSupport = "rocm"; };
           nativePackagesXpu = mkComfyPackages pkgs { gpuSupport = "xpu"; };
@@ -197,7 +197,7 @@
             dockerImage = nativePackages.dockerImage;
           }
           // pkgs.lib.optionalAttrs (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64) {
-            # CUDA package uses pre-built wheels (supports all GPU architectures)
+            # CUDA package uses pre-built wheels for all supported GPU architectures
             cuda = nativePackagesCuda.default;
             dockerImageCuda = nativePackagesCuda.dockerImageCuda;
             rocm = nativePackagesRocm.default;
@@ -288,7 +288,7 @@
           comfyui-nix = self.legacyPackages.${final.stdenv.hostPlatform.system};
           comfyui = self.packages.${final.stdenv.hostPlatform.system}.default;
           comfy-ui = self.packages.${final.stdenv.hostPlatform.system}.default;
-          # CUDA variant (x86_64 Linux only) - uses pre-built wheels supporting all GPU architectures
+          # CUDA variant (x86_64 Linux only) - uses pre-built wheels for all supported GPU architectures
           comfy-ui-cuda =
             if final.stdenv.isLinux && final.stdenv.isx86_64 then
               self.packages.${final.stdenv.hostPlatform.system}.cuda

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -49,7 +49,7 @@ in
     type = "app";
     program = "${packages.cuda}/bin/comfy-ui";
     meta = {
-      description = "Run ComfyUI with CUDA (all GPU architectures)";
+      description = "Run ComfyUI with CUDA";
     };
   };
 }

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -112,6 +112,11 @@ let
         ps.pyjwt
         ps.bleach
       ]);
+      expectedCudaSuffix =
+        if expectedCudaVersion == null then
+          null
+        else
+          "cu${pkgs.lib.replaceStrings [ "." ] [ "" ] expectedCudaVersion}";
     in
     assert package.pythonRuntime.pkgs.torch.outPath == extended.pythonRuntime.pkgs.torch.outPath;
     assert package.pythonRuntime.pkgs.numpy.outPath == extended.pythonRuntime.pkgs.numpy.outPath;
@@ -135,7 +140,7 @@ let
         assert numpy.__version__
         assert torch.__version__
         ${pkgs.lib.optionalString (expectedCudaVersion != null) ''
-          assert torch.__version__.endswith("+cu130")
+          assert torch.__version__.endswith("+${expectedCudaSuffix}")
           assert torch.version.cuda == "${expectedCudaVersion}"
         ''}
         PY

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -101,7 +101,11 @@ let
     defaultModuleSystem.config.systemd.services.comfyui.serviceConfig.ExecStart;
   moduleExecStart = moduleSystem.config.systemd.services.comfyui.serviceConfig.ExecStart;
   mkExtraPythonPackagesCheck =
-    name: package:
+    {
+      name,
+      package,
+      expectedCudaVersion ? null,
+    }:
     let
       extended = package.withExtraPythonPackages (ps: [
         ps.bcrypt
@@ -130,6 +134,10 @@ let
         assert jwt.__version__
         assert numpy.__version__
         assert torch.__version__
+        ${pkgs.lib.optionalString (expectedCudaVersion != null) ''
+          assert torch.__version__.endswith("+cu130")
+          assert torch.version.cuda == "${expectedCudaVersion}"
+        ''}
         PY
         touch $out
       '';
@@ -186,13 +194,23 @@ in
   package-xpu = packages.xpu;
 }
 // pkgs.lib.optionalAttrs (packages ? cuda) {
-  extra-python-packages-cuda = mkExtraPythonPackagesCheck "extra-python-packages-cuda" packages.cuda;
+  extra-python-packages-cuda = mkExtraPythonPackagesCheck {
+    name = "extra-python-packages-cuda";
+    package = packages.cuda;
+    expectedCudaVersion = "13.0";
+  };
 }
 // pkgs.lib.optionalAttrs (packages ? rocm) {
-  extra-python-packages-rocm = mkExtraPythonPackagesCheck "extra-python-packages-rocm" packages.rocm;
+  extra-python-packages-rocm = mkExtraPythonPackagesCheck {
+    name = "extra-python-packages-rocm";
+    package = packages.rocm;
+  };
 }
 // pkgs.lib.optionalAttrs (packages ? xpu) {
-  extra-python-packages-xpu = mkExtraPythonPackagesCheck "extra-python-packages-xpu" packages.xpu;
+  extra-python-packages-xpu = mkExtraPythonPackagesCheck {
+    name = "extra-python-packages-xpu";
+    package = packages.xpu;
+  };
 }
 // {
 
@@ -228,7 +246,10 @@ in
         touch $out
       '';
 
-  extra-python-packages-runtime = mkExtraPythonPackagesCheck "extra-python-packages-runtime" packages.default;
+  extra-python-packages-runtime = mkExtraPythonPackagesCheck {
+    name = "extra-python-packages-runtime";
+    package = packages.default;
+  };
 
   pytest =
     let

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -10,7 +10,7 @@
       tag,
       comfyUiPackage,
       gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
-      cudaVersion ? "cu128",
+      cudaVersion ? "cu130",
       extraLabels ? { },
     }:
     let

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -13,7 +13,7 @@ let
   useCpu = cfg.gpuSupport == "none";
 
   # Determine which package to use based on configuration
-  # CUDA package uses pre-built wheels supporting all GPU architectures (Pascal through Blackwell)
+  # CUDA package uses pre-built wheels for all supported GPU architectures
   resolvePackage =
     if useCuda then
       pkgs.comfy-ui-cuda
@@ -105,9 +105,9 @@ in
         Select CUDA support for NVIDIA GPUs. This is recommended for most users
         with NVIDIA graphics cards as it provides significant performance improvements.
 
-        When selected, uses pre-built PyTorch CUDA wheels that support all GPU
-        architectures from Pascal (GTX 1080) through Blackwell (RTX 5090) in a single package.
-        Requires NVIDIA drivers to be installed on the system.
+        When selected, uses pre-built PyTorch CUDA 13 wheels that support GPU
+        architectures from Turing (RTX 20 series) through Blackwell (RTX 50 series)
+        in a single package. Requires NVIDIA driver 580 or newer.
 
         ---
 
@@ -147,15 +147,13 @@ in
         `nixpkgs.config.cudaCapabilities`. When set, this updates the global
         nixpkgs configuration, so it affects other CUDA packages too.
 
-        Note: ComfyUI's pre-built PyTorch wheels already support all GPU
-        architectures (Pascal through Blackwell). This setting is primarily useful
+        Note: ComfyUI's pre-built PyTorch wheels already support GPU architectures
+        from Turing through Blackwell. This setting is primarily useful
         for optimizing other CUDA-enabled packages in your system configuration.
 
         Example: [ "8.9" ] for Ada Lovelace (RTX 40xx) GPUs.
 
         Common values:
-        - "6.1": Pascal (GTX 1080/1070)
-        - "7.0": Volta (V100)
         - "7.5": Turing (RTX 20xx, GTX 16xx)
         - "8.0": Ampere (A100)
         - "8.6": Ampere (RTX 30xx)
@@ -191,7 +189,7 @@ in
       '';
       description = ''
         ComfyUI package to run. Automatically set based on `gpuSupport`:
-        - `gpuSupport = "cuda"`: CUDA package (supports all GPU architectures)
+        - `gpuSupport = "cuda"`: CUDA package (all supported GPU architectures)
         - `gpuSupport = "rocm"`: ROCm package (`gfx1100` tested)
         - `gpuSupport = "xpu"`: Intel XPU package (oneAPI / SYCL; Arc + Core Ultra iGPU)
         - Otherwise: CPU-only build

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -10,6 +10,7 @@ let
   useCuda = gpuSupport == "cuda" && pkgs.stdenv.isLinux;
   useRocm = gpuSupport == "rocm" && pkgs.stdenv.isLinux;
   useXpu = gpuSupport == "xpu" && pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64;
+  cudaPackages = pkgs.cudaPackages_13;
 
   # Intel XPU runtime libraries (Level Zero loader, Intel compute-runtime, OpenCL ICD)
   # Bundled as a fallback when /run/opengl-driver/lib isn't available (non-NixOS Linux,
@@ -28,7 +29,7 @@ let
   # (see `cudaLibs` in python-overrides.nix), which stamps an RPATH onto torch's
   # own .so files. That RPATH only resolves the DT_NEEDED entries of the ELF that
   # carries it, so it does nothing for code that dlopens by bare soname — e.g.
-  # torch.cuda._utils._get_nvrtc_library() calls ctypes.CDLL("libnvrtc.so.12")
+  # torch.cuda._utils._get_nvrtc_library() calls ctypes.CDLL("libnvrtc.so.13")
   # when a node JIT-compiles a kernel (SeedVR2's VAE attention does this). That
   # lookup goes through LD_LIBRARY_PATH and /etc/ld.so.cache instead, and NixOS
   # has no ld.so.cache — so it fails unless the directory is on LD_LIBRARY_PATH.
@@ -38,12 +39,12 @@ let
   # prepends /run/opengl-driver/lib so the driver's copy always wins.
   # See: https://github.com/utensils/comfyui-nix/issues/71
   cudaRuntimeLibs = lib.optionals useCuda (
-    with pkgs.cudaPackages;
+    with cudaPackages;
     [
-      cuda_cudart # libcudart.so.12
-      cuda_cupti # libcupti.so.12
-      cuda_nvrtc # libnvrtc.so.12 — the one issue #71 trips over
-      libcublas # libcublas.so.12, libcublasLt.so.12
+      cuda_cudart # libcudart.so.13
+      cuda_cupti # libcupti.so.13
+      cuda_nvrtc # libnvrtc.so.13 — the one issue #71 trips over
+      libcublas # libcublas.so.13, libcublasLt.so.13
       libcufft # libcufft.so.11
       libcufile # libcufile.so.0
       libcurand # libcurand.so.10
@@ -69,7 +70,7 @@ let
   # so joining it here costs no extra store size.
   cudaHome = pkgs.symlinkJoin {
     name = "cuda-home";
-    paths = with pkgs.cudaPackages; [
+    paths = with cudaPackages; [
       (lib.getDev cuda_cudart) # cuda_runtime.h, driver_types.h, ...
       (lib.getLib cuda_cudart)
       (lib.getOutput "include" cuda_nvrtc) # nvrtc.h
@@ -678,10 +679,10 @@ let
         # Point it at the exact store paths instead. All are overridable — a user
         # with a system CUDA toolkit can export these before launch.
         # See: https://github.com/utensils/comfyui-nix/issues/60
-        export TRITON_PTXAS_PATH="''${TRITON_PTXAS_PATH:-${pkgs.cudaPackages.cuda_nvcc}/bin/ptxas}"
-        export TRITON_LIBDEVICE_PATH="''${TRITON_LIBDEVICE_PATH:-${pkgs.cudaPackages.cuda_nvcc}/nvvm/libdevice/libdevice.10.bc}"
-        export TRITON_CUDACRT_PATH="''${TRITON_CUDACRT_PATH:-${pkgs.cudaPackages.cuda_cudart}/include}"
-        export TRITON_CUDART_PATH="''${TRITON_CUDART_PATH:-${pkgs.cudaPackages.cuda_cudart}/include}"
+        export TRITON_PTXAS_PATH="''${TRITON_PTXAS_PATH:-${cudaPackages.cuda_nvcc}/bin/ptxas}"
+        export TRITON_LIBDEVICE_PATH="''${TRITON_LIBDEVICE_PATH:-${cudaPackages.cuda_nvcc}/nvvm/libdevice/libdevice.10.bc}"
+        export TRITON_CUDACRT_PATH="''${TRITON_CUDACRT_PATH:-${cudaPackages.cuda_cudart}/include}"
+        export TRITON_CUDART_PATH="''${TRITON_CUDART_PATH:-${cudaPackages.cuda_cudart}/include}"
 
         # libcuda.so.1 belongs to the kernel driver, not to cudaPackages. Prefer
         # the NixOS driver directory; fall back to scanning LD_LIBRARY_PATH so
@@ -700,11 +701,11 @@ let
         fi
 
         # =====================================================================
-        # NVIDIA Blackwell / CUDA 12.x compatibility
+        # NVIDIA Blackwell allocator compatibility
         # =====================================================================
         # ComfyUI enables cudaMallocAsync automatically for CUDA builds unless a
         # device is explicitly blacklisted. On Blackwell cards with the current
-        # cu128 PyTorch wheels, users have reported generation-time crashes and
+        # PyTorch CUDA wheels, users have reported generation-time crashes and
         # ComfyUI's own warning recommends --disable-cuda-malloc for allocator
         # errors. Disable it automatically for RTX 50/Blackwell unless the user
         # already selected an allocator mode in extraArgs.
@@ -866,7 +867,7 @@ let
     name = "comfy-ui";
     tag = "cuda";
     comfyUiPackage = comfyUiPackage;
-    cudaVersion = "cu128";
+    cudaVersion = "cu130";
     extraLabels = {
       "org.opencontainers.image.version" = versions.comfyui.version;
       "com.nvidia.volumes.needed" = "nvidia_driver";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -45,10 +45,10 @@ let
       cuda_cupti # libcupti.so.13
       cuda_nvrtc # libnvrtc.so.13 — the one issue #71 trips over
       libcublas # libcublas.so.13, libcublasLt.so.13
-      libcufft # libcufft.so.11
+      libcufft # libcufft.so.12
       libcufile # libcufile.so.0
       libcurand # libcurand.so.10
-      libcusolver # libcusolver.so.11
+      libcusolver # libcusolver.so.12
       libcusparse # libcusparse.so.12
       libcusparse_lt # libcusparseLt.so.0
       libnvshmem # libnvshmem_host.so.3

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -77,9 +77,9 @@ let
       cuda_cudart # libcudart.so.13
       cuda_cupti # libcupti.so.13
       libcublas # libcublas.so.13, libcublasLt.so.13
-      libcufft # libcufft.so.11
+      libcufft # libcufft.so.12
       libcurand # libcurand.so.10
-      libcusolver # libcusolver.so.11
+      libcusolver # libcusolver.so.12
       libcusparse # libcusparse.so.12
       libcusparse_lt # libcusparseLt.so.0 (structured sparsity)
       libcufile # libcufile.so.0 (GPU Direct Storage)

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -11,11 +11,12 @@ let
   useXpu = gpuSupport == "xpu" && pkgs.stdenv.isLinux && pkgs.stdenv.hostPlatform.isx86_64;
   useDarwinArm64 = pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64;
   sentencepieceNoGperf = pkgs.sentencepiece.override { withGPerfTools = false; };
+  cudaPackages = pkgs.cudaPackages_13;
 
   # Pre-built PyTorch CUDA wheels from pytorch.org
   # These avoid compiling PyTorch from source (which requires 30-60GB RAM and hours of build time)
-  # The wheels bundle CUDA 12.8 libraries, so no separate CUDA toolkit needed at runtime
-  cudaWheels = versions.pytorchWheels.cu128;
+  # CUDA runtime libraries are supplied by nixpkgs, so no separate toolkit is needed at runtime
+  cudaWheels = versions.pytorchWheels.cu130;
 
   # Pre-built PyTorch ROCm wheels from pytorch.org
   # These avoid compiling PyTorch from source (which requires 30-60GB RAM and hours of build time)
@@ -71,21 +72,21 @@ let
 
   # CUDA libraries needed by PyTorch wheels (for auto-patchelf)
   cudaLibs = pkgs.lib.optionals useCuda (
-    with pkgs.cudaPackages;
+    with cudaPackages;
     [
-      cuda_cudart # libcudart.so.12
-      cuda_cupti # libcupti.so.12
-      libcublas # libcublas.so.12, libcublasLt.so.12
+      cuda_cudart # libcudart.so.13
+      cuda_cupti # libcupti.so.13
+      libcublas # libcublas.so.13, libcublasLt.so.13
       libcufft # libcufft.so.11
       libcurand # libcurand.so.10
       libcusolver # libcusolver.so.11
       libcusparse # libcusparse.so.12
-      libcusparse_lt # libcusparseLt.so.0 (structured sparsity, new in cu128)
-      libcufile # libcufile.so.0 (GPU Direct Storage, new in cu128)
-      libnvshmem # libnvshmem_host.so.3 (multi-GPU shared memory, new in cu128)
+      libcusparse_lt # libcusparseLt.so.0 (structured sparsity)
+      libcufile # libcufile.so.0 (GPU Direct Storage)
+      libnvshmem # libnvshmem_host.so.3 (multi-GPU shared memory)
       cudnn # libcudnn.so.9
       nccl # libnccl.so.2
-      cuda_nvrtc # libnvrtc.so.12
+      cuda_nvrtc # libnvrtc.so.13
     ]
   );
 
@@ -146,14 +147,11 @@ lib.optionalAttrs useCuda {
     doCheck = false;
 
     # Passthru attributes expected by downstream packages (xformers, bitsandbytes, etc.)
-    # The wheel bundles CUDA 12.8 and supports all GPU architectures
     passthru = {
       cudaSupport = true;
       rocmSupport = false;
-      # All architectures supported by pre-built wheel (Pascal through Blackwell)
+      # All architectures supported by the pre-built wheel
       cudaCapabilities = [
-        "6.1"
-        "7.0"
         "7.5"
         "8.0"
         "8.6"
@@ -162,8 +160,8 @@ lib.optionalAttrs useCuda {
         "10.0" # Blackwell (B100/B200 data center)
         "12.0" # Blackwell (RTX 50xx consumer)
       ];
-      # Provide cudaPackages for packages that need it (use default version)
-      cudaPackages = pkgs.cudaPackages;
+      # Provide the matching CUDA package set for downstream packages
+      inherit cudaPackages;
       rocmPackages = { };
     };
 
@@ -909,7 +907,7 @@ lib.optionalAttrs useCuda {
 
 # Relax xformers torch version requirement (relaxes torch version constraint)
 # Limit build parallelism to prevent OOM during flash-attention CUDA kernel compilation
-# (sm_90 CUTLASS kernels with CUDA 12.8 consume ~3GB RAM each)
+# (sm_90 CUTLASS kernels consume ~3GB RAM each)
 // lib.optionalAttrs (prev ? xformers) {
   xformers = prev.xformers.overridePythonAttrs (old: {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.pythonRelaxDepsHook ];

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -206,22 +206,22 @@
         hash = "sha256-8cv9/Ru9++conUenTzb/bF2HwyBWBiAv71p/tpP2HPA=";
       };
     };
-    # Linux x86_64 CUDA 12.8
-    cu128 = {
+    # Linux x86_64 CUDA 13.0
+    cu130 = {
       torch = {
         version = "2.10.0";
-        url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl";
-        hash = "sha256-Yo6JvVEQztfevuKlfGmVlyW3+8ZOq4GjndcORsfii6U=";
+        url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+        hash = "sha256-hY8MvMeNcm/qlJnrNGT6qYOS+gk4RaMmIgm9Imt4RNY=";
       };
       torchvision = {
         version = "0.25.0";
-        url = "https://download.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl";
-        hash = "sha256-ElWgyiv5h6z58QO5bFxM/jQV/Eoe7xf6CK9SegSk9XM=";
+        url = "https://download.pytorch.org/whl/cu130/torchvision-0.25.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+        hash = "sha256-wvXjjwzVeieW5FA8DxM2XeugHbwWfvgg8L7sfKlvXy4=";
       };
       torchaudio = {
         version = "2.10.0";
-        url = "https://download.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl";
-        hash = "sha256-0muRoXPO5tuav/aLSNZCNpUP/FYo0GRI7N16xWhB4Qo=";
+        url = "https://download.pytorch.org/whl/cu130/torchaudio-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+        hash = "sha256-7Vc+cxm6mm4Te0iV7d9Mn81CS7ThCmKSZ9ZLVazFf7s=";
       };
     };
     # Linux x86_64 ROCm 7.1


### PR DESCRIPTION
Upgrade so current image-generation GPUs can use CUDA 13 optimizations.
This especially benefits Blackwell instead of leaving it on CUDA 12.8.

Keep torch 2.10.0 with torchvision 0.25.0 and torchaudio 2.10.0.
Switch their Linux wheels from cu128 to cu130.
The implementation now:

- pins the cu130 wheel hashes
- uses nixpkgs `cudaPackages_13` for auto-patching and runtime libraries
- provides the matching toolchain through `CUDA_HOME` and Triton paths
- exposes the matching CUDA package set to downstream extension builds
- verifies the cu130 suffix and `torch.version.cuda == "13.0"` in CI
- documents the runtime, driver, and architecture requirements

CUDA 13 removes compiler and library support for pre-Turing GPUs.
Consequently Pascal and Volta support is removed.
NVIDIA driver 580 or newer is now required.
Users of those older architectures must remain on an earlier release.

Validation included:

- `nix flake check`
- a full CUDA package build
- an overridden NixOS configuration build
- CUDA tensor operations on an RTX 5090 with driver 595.71.05
- xformers, Triton, SageAttention, and ComfyUI startup
- end-to-end SDXL image generation with PyTorch 2.10.0+cu130