### PR TITLE
fix(module): disable nixpkgs comfyui module to avoid namespace clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,13 @@ nix profile add github:utensils/comfyui-nix#xpu
 }
 ```
 
+> **Note:** nixpkgs ships its own `services.comfyui` module
+> (`nixos/modules/services/misc/comfyui.nix`). Importing this module automatically disables
+> the nixpkgs one, so the two no longer collide with
+> `error: The option 'services.comfyui.enable' ... is already declared`. All
+> `services.comfyui.*` options come from this flake. To use the nixpkgs service instead,
+> simply do not import `comfyui-nix.nixosModules.default`.
+
 ### Module Options
 
 | Option          | Default              | Description                                      |

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -49,6 +49,37 @@ let
         }
       ];
     };
+  # Regression guard for the nixpkgs namespace clash: nixpkgs ships its own
+  # nixos/modules/services/misc/comfyui.nix declaring `services.comfyui.enable`,
+  # which collides with this module unless it is disabled. The stub below claims the
+  # upstream module key so the conflict is reproducible against any nixpkgs revision,
+  # including ones predating the upstream module.
+  upstreamModuleStub =
+    {
+      modulesPath,
+      lib,
+      ...
+    }:
+    {
+      imports = [
+        {
+          key = "${modulesPath}/services/misc/comfyui.nix";
+          options.services.comfyui.enable = lib.mkEnableOption "ComfyUI (nixpkgs)";
+        }
+      ];
+    };
+  namespaceSystem = nixpkgs.lib.nixosSystem {
+    system = pkgs.stdenv.hostPlatform.system;
+    modules = [
+      nixosModule
+      upstreamModuleStub
+      { system.stateVersion = "26.05"; }
+    ];
+  };
+  namespaceDeclarations = namespaceSystem.options.services.comfyui.enable.declarations;
+  upstreamModuleDisabled =
+    pkgs.lib.length namespaceDeclarations == 1
+    && pkgs.lib.hasSuffix "nix/modules/comfyui.nix" (pkgs.lib.head namespaceDeclarations);
   defaultModuleSystem = evalModule { };
   moduleSystem = evalModule {
     extraPythonPackages = ps: [
@@ -229,6 +260,10 @@ in
       '';
 
   extra-python-packages-runtime = mkExtraPythonPackagesCheck "extra-python-packages-runtime" packages.default;
+
+  nixos-module-namespace =
+    assert upstreamModuleDisabled;
+    pkgs.runCommand "nixos-module-namespace" { } "touch $out";
 
   pytest =
     let

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -85,6 +85,12 @@ let
   '';
 in
 {
+  # nixpkgs gained its own `services.comfyui` module (nixos/modules/services/misc/comfyui.nix).
+  # Importing both declares `services.comfyui.enable` twice and evaluation fails, so this
+  # module takes over the namespace. Disabling a module path that does not exist in the
+  # user's nixpkgs is a no-op, so this stays compatible with older releases.
+  disabledModules = [ "services/misc/comfyui.nix" ];
+
   options.services.comfyui = {
     enable = lib.mkEnableOption "ComfyUI service";
 


### PR DESCRIPTION
Fixes #82

## Problem

nixpkgs unstable now ships `nixos/modules/services/misc/comfyui.nix` (registered in `module-list.nix`), which declares `services.comfyui.enable`. Importing `comfyui-nix.nixosModules.default` on top of it aborts evaluation:

```
error: The option `services.comfyui.enable' in `<nixpkgs>/nixos/modules/services/misc/comfyui.nix'
is already declared in `<comfyui-nix>/nix/modules/comfyui.nix'.
```

Root cause is `lib.mergeOptionDecls`: both declarations set `default` and `description`, and that combination is an unconditional throw — the option cannot be co-declared.

## Fix

`nix/modules/comfyui.nix` now claims the namespace:

```nix
disabledModules = [ "services/misc/comfyui.nix" ];
```

`lib.modules.isDisabled` resolves the relative string against `modulesPath` and filters by module key; keys that match nothing are silently ignored. So this is a no-op on nixpkgs revisions predating the upstream module, and on 25.05/25.11.

Users who want the nixpkgs service simply don't import this flake's module.

## Regression check

`nix/checks.nix` gains `nixos-module-namespace`, which evaluates a `nixosSystem` with this module plus a stub that claims the upstream module's key (`${modulesPath}/services/misc/comfyui.nix`) and declares `services.comfyui.enable`. It reproduces the conflict against *any* nixpkgs revision, including the flake's current pin (which predates the upstream module), then asserts the option has exactly one declaration and that it comes from this repo.

Verified both directions:

- with the fix: check builds
- with `disabledModules` removed: `error: The option 'services.comfyui.enable' ... is already declared` — the exact error from the issue

## Also

- README note under **NixOS Module** explaining the override and how to opt out.

Peer-reviewed by Codex (no findings).