### PR TITLE
docs: stop restating the ComfyUI version in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Version Management
 
-- Current ComfyUI version: v0.19.3 (pinned in `nix/versions.nix`; released 2026-04-17)
+- Current ComfyUI version: read `comfyui.version` in `nix/versions.nix` — that file is the single source of truth; do not restate the version here (it drifts)
 - To update ComfyUI: modify `version`, `rev`, and `hash` in `nix/versions.nix`
 - Vendored wheels (spandrel, frontend, docs, etc.) also pinned in `nix/versions.nix`
 - Template input files: auto-generated in `nix/template-inputs.nix`


### PR DESCRIPTION
`CLAUDE.md` claimed the pinned ComfyUI version was **v0.19.3 (released 2026-04-17)** while `nix/versions.nix` has had **0.30.2** since #78.

Restating the version in two places guarantees drift — the doc line has no reason to be updated during a routine version bump, so it silently rots. Replaced it with a pointer to `nix/versions.nix` as the single source of truth.

Checked the rest of the docs: `README.md` has no hardcoded ComfyUI version, and the `docs/pr-comfyui-*.md` files are historical PR notes whose versions are correct for what they describe.

Docs only — no code or build changes.