### PR TITLE
docs(cuda): correct CUDA library provenance, drop dead docker arg

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -10,7 +10,6 @@
       tag,
       comfyUiPackage,
       gpuSupport ? "none", # "none", "cuda", "rocm", "xpu"
-      cudaVersion ? "cu130",
       extraLabels ? { },
     }:
     let

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -867,7 +867,6 @@ let
     name = "comfy-ui";
     tag = "cuda";
     comfyUiPackage = comfyUiPackage;
-    cudaVersion = "cu130";
     extraLabels = {
       "org.opencontainers.image.version" = versions.comfyui.version;
       "com.nvidia.volumes.needed" = "nvidia_driver";

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -70,7 +70,22 @@ let
     pkgs.glib
   ];
 
-  # CUDA libraries needed by PyTorch wheels (for auto-patchelf)
+  # CUDA libraries needed by PyTorch wheels (for auto-patchelf).
+  #
+  # These replace the `nvidia-*` PyPI wheels the torch wheel asks for, which we
+  # strip from its metadata. nixpkgs does not always carry the exact versions
+  # PyTorch pinned, and because the SONAMEs match, auto-patchelf accepts the
+  # substitution silently — any mismatch surfaces only at runtime. Current deltas
+  # against `torch-2.10.0+cu130`:
+  #
+  #   cuDNN         wheel wants 9.15.1.9  nixpkgs has 9.13.0.50  (older — risky direction)
+  #   NCCL          wheel wants 2.28.9    nixpkgs has 2.28.7     (older — risky direction)
+  #   cuSPARSELt    wheel wants 0.8.0     nixpkgs has 0.8.1.1    (newer — safe direction)
+  #
+  # The cuDNN/NCCL deltas are latent, not active: every symbol libtorch_cuda.so
+  # imports from them is still exported by the older builds. They clear once the
+  # nixpkgs input is bumped, which is blocked on the vendored-wheel metadata work
+  # in https://github.com/utensils/comfyui-nix/issues/81
   cudaLibs = pkgs.lib.optionals useCuda (
     with cudaPackages;
     [
@@ -103,7 +118,9 @@ let
 in
 final: prev:
 # CUDA torch from pre-built wheels - avoids 30-60GB RAM compilation
-# The wheels bundle CUDA libraries internally, providing full GPU support
+# Unlike the ROCm wheels, these do NOT bundle their CUDA libraries: the wheel
+# declares them as separate `nvidia-*` PyPI requirements, which we strip from the
+# metadata below and satisfy from nixpkgs via `cudaLibs` instead.
 lib.optionalAttrs useCuda {
   torch = final.buildPythonPackage {
     pname = "torch";


### PR DESCRIPTION
Follow-up to #79, from the post-merge review.

## 1. The bundling comment was wrong

`nix/python-overrides.nix` claimed *"The wheels bundle CUDA libraries internally, providing full GPU support"*. That holds for the ROCm wheels, but not the CUDA ones — the cu130 wheel declares its CUDA deps as separate `nvidia-*` PyPI requirements, which we strip from the metadata and satisfy from nixpkgs via `cudaLibs`. With the old comment in place, `cudaLibs` looks redundant.

## 2. Recorded the wheel-vs-nixpkgs version deltas

Documented where the substitution actually happens:

| | wheel pins | nixpkgs supplies | direction |
|---|---|---|---|
| cuDNN | 9.15.1.9 | 9.13.0.50 | older ⚠️ |
| NCCL | 2.28.9 | 2.28.7 | older ⚠️ |
| cuSPARSELt | 0.8.0 | 0.8.1.1 | newer ✅ |

Because the SONAMEs match, auto-patchelf accepts these silently and nothing fails at build time. The cuDNN/NCCL deltas are latent rather than active — every symbol `libtorch_cuda.so` imports from them is still exported by the older builds (83 cuDNN imports, 36 NCCL imports, 0 missing). They clear when the nixpkgs input is bumped, which is blocked on #81.

## 3. Dead argument

`mkDockerImage` accepted `cudaVersion` and never read it. Removed the parameter and the call site in `nix/packages.nix`.

## Verification

- `nix flake check --no-build` passes
- `nixfmt`, `shellcheck`, `nixos-module-namespace` build clean locally
- `dockerImageCuda` still evaluates after the argument removal
- Peer-reviewed by Codex — no findings

Comments and a dead argument only; no runtime behavior change.

## Not included

An assertion that `torch`'s compiled arch list still covers Turing→Blackwell would be the natural guard for #79's headline claim, but it needs the full CUDA closure to verify locally and I could not build it in reasonable time. Shipping an unverified CI assertion into an already-strained check isn't a good trade — noted as a follow-up instead.