### PR TITLE
ci: let the full flake check reuse the backend builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
   # backend-specific Torch/NumPy stack or ship dependencies that fail to import.
   extra-python-packages:
     runs-on: ubuntu-latest
+    env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,10 +91,14 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
+      # Push the backend Torch closures so the `check` job below substitutes them
+      # instead of recompiling. Same conditional-pushFilter pattern as the `build`
+      # job: fork PRs get no secret, so they fall back to read-only.
       - uses: cachix/cachix-action@v14
         with:
           name: comfyui
-          pushFilter: "-"
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}
 
       - uses: cachix/cachix-action@v14
         with:
@@ -110,9 +116,20 @@ jobs:
             --print-build-logs --max-jobs 1 --cores 2
 
   # Full nix flake check (includes package build) — only on main/tags
+  #
+  # Depends on extra-python-packages so the backend Torch closures are already in
+  # Cachix by the time this runs. Without that dependency both jobs start together
+  # and each compiles the same CUDA closure from source — xformers' CUTLASS kernels
+  # alone are multi-hour on a 4-core hosted runner — so the work is done twice and
+  # this job cannot benefit from the pushes happening beside it. Serializing costs
+  # nothing overall: the 6h ceiling is per job, not per workflow.
   check:
     if: github.event_name != 'pull_request'
+    needs: extra-python-packages
     runs-on: ubuntu-latest
+    # Fail with a clear signal instead of an opaque runner shutdown if the
+    # substitution assumption ever stops holding.
+    timeout-minutes: 350
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fixes the `check` job failure on main.

## What happened

Run [31558823643](https://github.com/utensils/comfyui-nix/actions/runs/31558823643) on `main` died after 3h 19m:

```
##[error]Process completed with exit code 143
##[error]The runner has received a shutdown signal.
```

It was mid-xformers CUTLASS compilation. No OOM in the log and no disk pressure — the runner had 114 GB free after the cleanup step. That commit was still cu128, so this predates the CUDA 13 migration in #79, though #79 makes it worse: that PR's CUDA job took 5h 10m against a 6h ceiling.

## Root cause

`check` had no `needs:`, so it started at the same time as `extra-python-packages` and independently rebuilt the same backend Torch closures. The same expensive compile ran twice per run, in parallel, with no sharing.

Serializing alone would not have helped, and I initially got this wrong — Codex caught it in review. **Every job except `build` was configured read-only:** `pushFilter: "-"` and no `authToken`. And `build` has `needs: check`, so it runs *after*. Nothing a run built was ever available to that run.

## Fix

1. `extra-python-packages` now pushes to the comfyui Cachix, using the same conditional pattern already in the `build` job:
   ```yaml
   authToken: ${{ env.CACHIX_AUTH_TOKEN }}
   pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}
   ```
   Fork PRs have no secret, so they fall back to read-only rather than failing.
2. `check` gains `needs: extra-python-packages`, so the closures are in the cache before it starts and it substitutes rather than compiles.
3. Explicit `timeout-minutes: 350` on `check`, so a future regression fails with a clear signal instead of an opaque runner shutdown.

Serializing costs nothing overall — the 6h ceiling is per job, not per workflow, and it removes a duplicated multi-hour compile.

## Verification

- `actionlint` clean: 38 shellcheck infos before and after, all pre-existing in the Docker manifest jobs, none from this change
- Job graph parses with no cycles and all `needs` resolve: `lint` ∥ `extra-python-packages` → `check` → `build` → `create-manifests` → `update-description`
- Cachix step config verified via `yq` to render the intended `authToken`/`pushFilter` pair
- Codex reviewed twice — it rejected the first version, and confirmed this one

The real proof is the next main run completing, which I'll be watching.