### PR TITLE
fix: repair Python runtime dependencies for newer nixpkgs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,51 @@ jobs:
           nix build .#checks.x86_64-linux.shellcheck --print-build-logs
           nix build .#checks.x86_64-linux.pytest --print-build-logs
 
+  # Exercise package metadata against nixpkgs with the runtime dependency hook
+  # enabled. Remove the override once the flake follows this revision or newer.
+  python-runtime-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
+          docker system prune -af || true
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: comfyui
+          pushFilter: "-"
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: nix-community
+          pushFilter: "-"
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: cuda-maintainers
+          pushFilter: "-"
+
+      - name: Check Python runtime dependencies
+        run: |
+          nix build .#checks.x86_64-linux.python-runtime-deps \
+            --override-input nixpkgs github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0 \
+            --no-write-lock-file \
+            --print-build-logs
+
   # Realize the extended runtime for every backend so PRs cannot replace the
   # backend-specific Torch/NumPy stack or ship dependencies that fail to import.
   extra-python-packages:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,8 +98,10 @@ jobs:
 
       - name: Check Python runtime dependencies
         run: |
+          nixpkgs_rev="$(nix eval --raw --file nix/versions.nix ci.runtimeDepsNixpkgs.rev)"
+          nixpkgs_hash="$(nix eval --raw --file nix/versions.nix ci.runtimeDepsNixpkgs.hash)"
           nix build .#checks.x86_64-linux.python-runtime-deps \
-            --override-input nixpkgs github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0 \
+            --override-input nixpkgs "github:NixOS/nixpkgs/$nixpkgs_rev?narHash=$nixpkgs_hash" \
             --no-write-lock-file \
             --print-build-logs
 

--- a/flake.nix
+++ b/flake.nix
@@ -274,6 +274,7 @@
             packages = self'.packages;
             pythonRuntime = nativePackages.pythonRuntime;
             pythonPackages = (mkPython pkgs "none").pkgs;
+            vendoredPackages = nativePackages.vendoredPackages;
             nixosModule = self.nixosModules.default;
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -273,6 +273,7 @@
               ;
             packages = self'.packages;
             pythonRuntime = nativePackages.pythonRuntime;
+            pythonPackages = (mkPython pkgs "none").pkgs;
             nixosModule = self.nixosModules.default;
           };
         };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -4,6 +4,7 @@
   source,
   packages,
   pythonRuntime,
+  pythonPackages,
   nixosModule,
 }:
 let
@@ -180,6 +181,7 @@ let
 in
 {
   package = packages.default;
+  facexlib-runtime-deps = pythonPackages.facexlib;
 }
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {
   comfy-extras-imports =

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -186,6 +186,9 @@ in
   gradio-client-runtime-deps = vendoredPackages.gradioClient;
   gradio-runtime-deps = vendoredPackages.gradio;
   manager-runtime-deps = vendoredPackages.comfyuiManager;
+  mss-runtime-deps =
+    assert !pythonPackages.mss.doInstallCheck;
+    pythonPackages.mss;
 }
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {
   comfy-extras-imports =

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -184,6 +184,7 @@ in
   package = packages.default;
   facexlib-runtime-deps = pythonPackages.facexlib;
   gradio-client-runtime-deps = vendoredPackages.gradioClient;
+  gradio-runtime-deps = vendoredPackages.gradio;
   manager-runtime-deps = vendoredPackages.comfyuiManager;
 }
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -236,6 +236,29 @@ in
   package-xpu = packages.xpu;
 }
 // pkgs.lib.optionalAttrs (packages ? cuda) {
+  cuda-torch-runtime-deps =
+    pkgs.runCommand "cuda-torch-runtime-deps"
+      {
+        nativeBuildInputs = [ packages.cuda.pythonRuntime ];
+      }
+      ''
+        ${packages.cuda.pythonRuntime}/bin/python - <<'PY'
+        import importlib.metadata
+
+        import setuptools
+        import torch
+
+        requirements = importlib.metadata.requires("torch") or []
+        removed_requirements = ("cuda-bindings", "nvidia-", "triton")
+
+        assert not any(
+            requirement.startswith(removed_requirements) for requirement in requirements
+        )
+        assert setuptools.__version__
+        assert torch.__version__
+        PY
+        touch $out
+      '';
   extra-python-packages-cuda = mkExtraPythonPackagesCheck {
     name = "extra-python-packages-cuda";
     package = packages.cuda;

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -183,6 +183,7 @@ in
 {
   package = packages.default;
   facexlib-runtime-deps = pythonPackages.facexlib;
+  gradio-client-runtime-deps = vendoredPackages.gradioClient;
   manager-runtime-deps = vendoredPackages.comfyuiManager;
 }
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -207,43 +207,27 @@ let
       ''
     else
       null;
+  runtimeDepsPackages = {
+    facexlib = pythonPackages.facexlib;
+    gradio-client = vendoredPackages.gradioClient;
+    gradio = vendoredPackages.gradio;
+    manager = vendoredPackages.comfyuiManager;
+    mss = mssRuntimeDeps;
+  }
+  // pkgs.lib.optionalAttrs (cudaTorchRuntimeDeps != null) {
+    cuda-torch = cudaTorchRuntimeDeps;
+  };
+  runtimeDepsChecks = pkgs.lib.mapAttrs' (
+    name: package: pkgs.lib.nameValuePair "${name}-runtime-deps" package
+  ) runtimeDepsPackages;
 in
 {
   package = packages.default;
-  facexlib-runtime-deps = pythonPackages.facexlib;
-  gradio-client-runtime-deps = vendoredPackages.gradioClient;
-  gradio-runtime-deps = vendoredPackages.gradio;
-  manager-runtime-deps = vendoredPackages.comfyuiManager;
-  mss-runtime-deps = mssRuntimeDeps;
   python-runtime-deps = pkgs.linkFarm "python-runtime-deps" (
-    [
-      {
-        name = "facexlib";
-        path = pythonPackages.facexlib;
-      }
-      {
-        name = "gradio-client";
-        path = vendoredPackages.gradioClient;
-      }
-      {
-        name = "gradio";
-        path = vendoredPackages.gradio;
-      }
-      {
-        name = "manager";
-        path = vendoredPackages.comfyuiManager;
-      }
-      {
-        name = "mss";
-        path = mssRuntimeDeps;
-      }
-    ]
-    ++ pkgs.lib.optional (cudaTorchRuntimeDeps != null) {
-      name = "cuda-torch";
-      path = cudaTorchRuntimeDeps;
-    }
+    pkgs.lib.mapAttrsToList (name: path: { inherit name path; }) runtimeDepsPackages
   );
 }
+// runtimeDepsChecks
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {
   comfy-extras-imports =
     pkgs.runCommand "comfy-extras-imports"
@@ -293,7 +277,6 @@ in
   package-xpu = packages.xpu;
 }
 // pkgs.lib.optionalAttrs (packages ? cuda) {
-  cuda-torch-runtime-deps = cudaTorchRuntimeDeps;
   extra-python-packages-cuda = mkExtraPythonPackagesCheck {
     name = "extra-python-packages-cuda";
     package = packages.cuda;

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -5,6 +5,7 @@
   packages,
   pythonRuntime,
   pythonPackages,
+  vendoredPackages,
   nixosModule,
 }:
 let
@@ -182,6 +183,7 @@ in
 {
   package = packages.default;
   facexlib-runtime-deps = pythonPackages.facexlib;
+  manager-runtime-deps = vendoredPackages.comfyuiManager;
 }
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {
   comfy-extras-imports =

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -179,6 +179,34 @@ let
         PY
         touch $out
       '';
+  mssRuntimeDeps =
+    assert !pythonPackages.mss.doInstallCheck;
+    pythonPackages.mss;
+  cudaTorchRuntimeDeps =
+    if packages ? cuda then
+      let
+        cudaTorchPython = packages.cuda.pythonRuntime.pkgs.python.withPackages (ps: [ ps.torch ]);
+      in
+      pkgs.runCommand "cuda-torch-runtime-deps" { nativeBuildInputs = [ cudaTorchPython ]; } ''
+        ${cudaTorchPython}/bin/python - <<'PY'
+        import importlib.metadata
+
+        import setuptools
+        import torch
+
+        requirements = importlib.metadata.requires("torch") or []
+        removed_requirements = ("cuda-bindings", "nvidia-", "triton")
+
+        assert not any(
+            requirement.startswith(removed_requirements) for requirement in requirements
+        )
+        assert setuptools.__version__
+        assert torch.__version__
+        PY
+        touch $out
+      ''
+    else
+      null;
 in
 {
   package = packages.default;
@@ -186,9 +214,35 @@ in
   gradio-client-runtime-deps = vendoredPackages.gradioClient;
   gradio-runtime-deps = vendoredPackages.gradio;
   manager-runtime-deps = vendoredPackages.comfyuiManager;
-  mss-runtime-deps =
-    assert !pythonPackages.mss.doInstallCheck;
-    pythonPackages.mss;
+  mss-runtime-deps = mssRuntimeDeps;
+  python-runtime-deps = pkgs.linkFarm "python-runtime-deps" (
+    [
+      {
+        name = "facexlib";
+        path = pythonPackages.facexlib;
+      }
+      {
+        name = "gradio-client";
+        path = vendoredPackages.gradioClient;
+      }
+      {
+        name = "gradio";
+        path = vendoredPackages.gradio;
+      }
+      {
+        name = "manager";
+        path = vendoredPackages.comfyuiManager;
+      }
+      {
+        name = "mss";
+        path = mssRuntimeDeps;
+      }
+    ]
+    ++ pkgs.lib.optional (cudaTorchRuntimeDeps != null) {
+      name = "cuda-torch";
+      path = cudaTorchRuntimeDeps;
+    }
+  );
 }
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {
   comfy-extras-imports =
@@ -239,29 +293,7 @@ in
   package-xpu = packages.xpu;
 }
 // pkgs.lib.optionalAttrs (packages ? cuda) {
-  cuda-torch-runtime-deps =
-    pkgs.runCommand "cuda-torch-runtime-deps"
-      {
-        nativeBuildInputs = [ packages.cuda.pythonRuntime ];
-      }
-      ''
-        ${packages.cuda.pythonRuntime}/bin/python - <<'PY'
-        import importlib.metadata
-
-        import setuptools
-        import torch
-
-        requirements = importlib.metadata.requires("torch") or []
-        removed_requirements = ("cuda-bindings", "nvidia-", "triton")
-
-        assert not any(
-            requirement.startswith(removed_requirements) for requirement in requirements
-        )
-        assert setuptools.__version__
-        assert torch.__version__
-        PY
-        touch $out
-      '';
+  cuda-torch-runtime-deps = cudaTorchRuntimeDeps;
   extra-python-packages-cuda = mkExtraPythonPackagesCheck {
     name = "extra-python-packages-cuda";
     package = packages.cuda;

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -895,6 +895,7 @@ let
 in
 {
   default = comfyUiPackage;
+  vendoredPackages = vendored;
   inherit
     dockerImage
     dockerImageCuda

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -946,6 +946,15 @@ lib.optionalAttrs useCuda {
   });
 }
 
+# mss runs screenshot tests through a virtual X server. They are not relevant
+# to ComfyUI's runtime dependency closure and can fail in a headless Nix build
+# sandbox. Remove this override once nixpkgs' mss checks are sandbox-independent.
+// lib.optionalAttrs (prev ? mss) {
+  mss = prev.mss.overridePythonAttrs (_old: {
+    doCheck = false;
+  });
+}
+
 # Disable filterpy tests on Darwin (test_hinfinity triggers BPT trap in pytest)
 // lib.optionalAttrs (prev ? filterpy) {
   filterpy = prev.filterpy.overridePythonAttrs (old: {

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -994,6 +994,14 @@ lib.optionalAttrs useCuda {
     dontBuild = true;
     dontConfigure = true;
     nativeBuildInputs = [ pkgs.gnused ];
+    # facexlib's wheel names the PyPI opencv-python distribution, while nixpkgs
+    # opencv4 provides the required cv2 module without matching distribution
+    # metadata. Remove this when facexlib accepts a system OpenCV provider.
+    pythonRemoveDeps = [ "opencv-python" ];
+    # pythonRemoveDeps normally runs in postBuild, which this prebuilt wheel
+    # skips. Remove this phase override when nixpkgs rewrites wheel metadata
+    # before its runtime dependency check.
+    preInstallPhases = [ "pythonRelaxDepsHook" ];
     propagatedBuildInputs = with final; [
       numpy
       opencv4
@@ -1002,6 +1010,7 @@ lib.optionalAttrs useCuda {
       torchvision
       filterpy
       numba
+      tqdm
     ];
 
     # Patch misc.py to respect FACEXLIB_MODELPATH environment variable

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -140,11 +140,14 @@ lib.optionalAttrs useCuda {
     # libcuda.so.1 comes from the NVIDIA driver at runtime, not from cudaPackages
     autoPatchelfIgnoreMissingDeps = [ "libcuda.so.1" ];
 
-    # Remove nvidia-* and triton dependencies from wheel metadata
-    # These are provided by nixpkgs cudaPackages, not PyPI packages
+    # The CUDA wheel names PyPI CUDA packages that are provided by nixpkgs
+    # cudaPackages instead. The runtime dependency hook cannot recognize those
+    # system providers, so validate the rewritten installed metadata below.
+    dontCheckRuntimeDeps = true;
     postInstall = ''
       for metadata in "$out/${final.python.sitePackages}"/torch-*.dist-info/METADATA; do
         if [[ -f "$metadata" ]]; then
+          sed -i '/^Requires-Dist: cuda-bindings/d' "$metadata"
           sed -i '/^Requires-Dist: nvidia-/d' "$metadata"
           sed -i '/^Requires-Dist: triton/d' "$metadata"
         fi
@@ -158,6 +161,7 @@ lib.optionalAttrs useCuda {
       networkx
       jinja2
       fsspec
+      setuptools
     ];
     # Don't check for CUDA at import time (requires GPU)
     pythonImportsCheck = [ ];

--- a/nix/vendored-packages.nix
+++ b/nix/vendored-packages.nix
@@ -232,6 +232,13 @@ rec {
     version = versions.vendored.gradio.version;
     url = versions.vendored.gradio.url;
     hash = versions.vendored.gradio.hash;
+    pythonRelaxDeps = [
+      "aiofiles"
+      "pillow"
+      "pydantic"
+      "starlette"
+      "tomlkit"
+    ];
     propagatedBuildInputs = with python.pkgs; [
       aiofiles
       anyio

--- a/nix/vendored-packages.nix
+++ b/nix/vendored-packages.nix
@@ -157,6 +157,18 @@ rec {
     version = versions.vendored.manager.version;
     url = versions.vendored.manager.url;
     hash = versions.vendored.manager.hash;
+    propagatedBuildInputs = with python.pkgs; [
+      chardet
+      gitpython
+      huggingface-hub
+      pygithub
+      rich
+      toml
+      transformers
+      typer
+      typing-extensions
+      uv
+    ];
   };
 
   comfyKitchen = mkNativeWheel {

--- a/nix/vendored-packages.nix
+++ b/nix/vendored-packages.nix
@@ -11,9 +11,15 @@ let
       url,
       hash,
       propagatedBuildInputs ? [ ],
+      pythonRelaxDeps ? [ ],
     }:
     python.pkgs.buildPythonPackage {
-      inherit pname version propagatedBuildInputs;
+      inherit
+        pname
+        version
+        propagatedBuildInputs
+        pythonRelaxDeps
+        ;
       format = "wheel";
       src = pkgs.fetchurl { inherit url hash; };
       doCheck = false;
@@ -210,6 +216,7 @@ rec {
     version = versions.vendored.gradioClient.version;
     url = versions.vendored.gradioClient.url;
     hash = versions.vendored.gradioClient.hash;
+    pythonRelaxDeps = [ "websockets" ];
     propagatedBuildInputs = with python.pkgs; [
       fsspec
       httpx

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -1,4 +1,9 @@
 {
+  ci.runtimeDepsNixpkgs = {
+    rev = "65179426c83bb3f6bc14898b42ea1c6f01d374b0";
+    hash = "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=";
+  };
+
   comfyui = {
     version = "0.32.0";
     releaseDate = "2026-08-11T21:56:20Z";


### PR DESCRIPTION
## Summary

This fixes the Python package metadata failures exposed when nixpkgs enables `pythonRuntimeDepsCheckHook` by default.

- declare ComfyUI-Manager's runtime dependencies
- relax incompatible upstream bounds for `gradio-client` and `gradio`
- rewrite CUDA Torch metadata for dependencies supplied by nixpkgs and propagate `setuptools`
- keep nixpkgs `opencv4` as facexlib's `cv2` provider, remove only the incompatible `opencv-python` distribution requirement, and add `tqdm`
- disable `mss`'s display-dependent checks in ComfyUI's private Python package set
- add focused package checks and one aggregate runtime-dependency check
- add a CI job that runs the aggregate check against an exact, content-locked nixpkgs revision with the hook enabled

Closes #81.

## Verification

The branch is rebased onto `bbedf70` (`upstream/main`).

### Regression proof

The pre-fix state can be reproduced in a temporary worktree. This checks out the
merge base, restores only the three files that expose and define the final check
harness, and leaves every package fix absent:

```console
$ (
    set -e
    repo="$(git rev-parse --show-toplevel)"
    pr_head="$(git rev-parse HEAD)"
    base="bbedf70a08ef2395da0a4b905e35a32e39bfd143"
    worktree="$(mktemp -d)"
    trap 'cd "$repo" && git worktree remove --force "$worktree"' EXIT

    git worktree add --detach "$worktree" "$base"
    git -C "$worktree" restore --source="$pr_head" -- \
      flake.nix nix/checks.nix nix/packages.nix
    git -C "$worktree" add flake.nix nix/checks.nix nix/packages.nix

    cd "$worktree"
    if nix build .#checks.x86_64-linux.python-runtime-deps \
      --override-input nixpkgs 'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' \
      --no-write-lock-file \
      --no-link \
      --print-build-logs; then
      echo 'unexpected success: the pre-fix check should fail' >&2
      exit 1
    fi
  )
error: assertion '(! (pythonPackages).mss.doInstallCheck)' failed
```

The inner `nix build` exited 1 at the `mss` assertion, demonstrating that the
aggregate check fails without the package fixes. The wrapper exits successfully
only when that expected failure occurs and removes its temporary worktree on exit.

### Hook-enabled aggregate command used by CI

```console
$ nixpkgs_rev="$(nix eval --raw --file nix/versions.nix ci.runtimeDepsNixpkgs.rev)"
$ nixpkgs_hash="$(nix eval --raw --file nix/versions.nix ci.runtimeDepsNixpkgs.hash)"
$ nix build .#checks.x86_64-linux.python-runtime-deps \
    --override-input nixpkgs "github:NixOS/nixpkgs/$nixpkgs_rev?narHash=$nixpkgs_hash" \
    --no-write-lock-file \
    --no-link \
    --print-build-logs
```

The CI job's exact Nix command passed locally with revision `65179426c83bb3f6bc14898b42ea1c6f01d374b0` and hash `sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=`. This local result does not claim that the surrounding GitHub Actions job has executed successfully; hosted execution is verified separately by the PR checks.

### Repository-pinned checks

```console
$ nix build \
    .#checks.x86_64-linux.nixfmt \
    .#checks.x86_64-linux.ruff-check \
    .#checks.x86_64-linux.pyright-check \
    .#checks.x86_64-linux.shellcheck \
    .#checks.x86_64-linux.pytest \
    .#checks.x86_64-linux.python-runtime-deps \
    --no-link \
    --print-build-logs
```

Passed. Ruff reported no findings, Pyright reported 0 errors and 0 warnings, and pytest reported 38 passed.

### CUDA composition

```console
$ nix build .#cuda --no-link --print-build-logs
```

Passed.

### Full flake gate

```console
$ nix flake check --print-build-logs
```

Passed all 21 `x86_64-linux` checks. The longest upstream dependency suite was
`torchsde`, with 1,553 passed and 73 skipped in 41 minutes 13 seconds.

## Follow-up

The flake's primary nixpkgs input is unchanged. Once it reaches the hook-enabled revision or newer, the temporary CI input override can be removed.
