### PR TITLE
fix(checks): test backend torch wheels, not stock nixpkgs torch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,16 @@ jobs:
   # enabled. Remove the override once the flake follows this revision or newer.
   python-runtime-deps:
     runs-on: ubuntu-latest
+    # One backend per job: a single runner cannot hold three GPU torch closures.
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - python-runtime-deps
+          - cuda-torch-runtime-deps
+          - rocm-torch-runtime-deps
+          - xpu-torch-runtime-deps
+    name: python-runtime-deps (${{ matrix.check }})
     steps:
       - uses: actions/checkout@v4
 
@@ -100,10 +110,11 @@ jobs:
         run: |
           nixpkgs_rev="$(nix eval --raw --file nix/versions.nix ci.runtimeDepsNixpkgs.rev)"
           nixpkgs_hash="$(nix eval --raw --file nix/versions.nix ci.runtimeDepsNixpkgs.hash)"
-          nix build .#checks.x86_64-linux.python-runtime-deps \
+          nix build ".#checks.x86_64-linux.${{ matrix.check }}" \
             --override-input nixpkgs "github:NixOS/nixpkgs/$nixpkgs_rev?narHash=$nixpkgs_hash" \
             --no-write-lock-file \
-            --print-build-logs
+            --no-link \
+            --print-build-logs --max-jobs 1 --cores 2
 
   # Realize the extended runtime for every backend so PRs cannot replace the
   # backend-specific Torch/NumPy stack or ship dependencies that fail to import.

--- a/flake.nix
+++ b/flake.nix
@@ -273,7 +273,10 @@
               ;
             packages = self'.packages;
             pythonRuntime = nativePackages.pythonRuntime;
-            pythonPackages = (mkPython pkgs "none").pkgs;
+            # A function, not a fixed package set: the torch checks need the
+            # interpreter for a specific backend, and `pythonRuntime.pkgs` is
+            # the *unoverridden* nixpkgs set, so it cannot be used for that.
+            pythonFor = mkPython pkgs;
             vendoredPackages = nativePackages.vendoredPackages;
             nixosModule = self.nixosModules.default;
           };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -4,11 +4,12 @@
   source,
   packages,
   pythonRuntime,
-  pythonPackages,
+  pythonFor,
   vendoredPackages,
   nixosModule,
 }:
 let
+  pythonPackages = (pythonFor "none").pkgs;
   emptyExtendedPackage = packages.default.withExtraPythonPackages (_: [ ]);
   duplicateCorePackage = packages.default.withExtraPythonPackages (ps: [ ps.numpy ]);
   extendedPackage = packages.default.withExtraPythonPackages (ps: [
@@ -182,40 +183,81 @@ let
   mssRuntimeDeps =
     assert !pythonPackages.mss.doInstallCheck;
     pythonPackages.mss;
-  cudaTorchRuntimeDeps =
-    if packages ? cuda then
-      let
-        cudaTorchPython = packages.cuda.pythonRuntime.pkgs.python.withPackages (ps: [ ps.torch ]);
-      in
-      pkgs.runCommand "cuda-torch-runtime-deps" { nativeBuildInputs = [ cudaTorchPython ]; } ''
-        ${cudaTorchPython}/bin/python - <<'PY'
-        import importlib.metadata
+  # Every backend's torch comes from a pre-built wheel whose metadata names
+  # distributions nixpkgs supplies outside PyPI. Those requirements are dropped
+  # from the installed metadata (or waved through with dontCheckRuntimeDeps),
+  # so assert on the installed result instead of trusting the hook.
+  #
+  # The interpreter must come from `pythonFor <backend>`: `pythonRuntime.pkgs`
+  # is the unoverridden nixpkgs package set and yields the stock CPU torch,
+  # which would make every assertion below pass vacuously.
+  mkTorchRuntimeDeps =
+    {
+      backend,
+      removedRequirements,
+    }:
+    let
+      torchPython = (pythonFor backend).withPackages (ps: [ ps.torch ]);
+      removedTuple = pkgs.lib.concatMapStrings (r: ''"${r}", '') removedRequirements;
+    in
+    pkgs.runCommand "${backend}-torch-runtime-deps" { nativeBuildInputs = [ torchPython ]; } ''
+      ${torchPython}/bin/python - <<'PY'
+      import importlib.metadata
 
-        import setuptools
-        import torch
+      import setuptools
+      import torch
 
-        requirements = importlib.metadata.requires("torch") or []
-        removed_requirements = ("cuda-bindings", "nvidia-", "triton")
+      requirements = importlib.metadata.requires("torch") or []
+      removed_requirements = (${removedTuple})
 
-        assert not any(
-            requirement.startswith(removed_requirements) for requirement in requirements
-        )
-        assert setuptools.__version__
-        assert torch.__version__
-        PY
-        touch $out
-      ''
-    else
-      null;
+      assert not any(
+          requirement.startswith(removed_requirements) for requirement in requirements
+      )
+      assert setuptools.__version__
+      assert torch.__version__
+      assert "${expectedTorchVersions.${backend}}" in torch.__version__, torch.__version__
+      PY
+      touch $out
+    '';
+  # Guards against the check silently falling back to nixpkgs' CPU torch again.
+  expectedTorchVersions = {
+    cuda = "+cu";
+    rocm = "+rocm";
+    xpu = "+xpu";
+  };
+  torchRuntimeDepsChecks =
+    pkgs.lib.optionalAttrs (packages ? cuda) {
+      cuda-torch-runtime-deps = mkTorchRuntimeDeps {
+        backend = "cuda";
+        removedRequirements = [
+          "cuda-bindings"
+          "nvidia-"
+          "triton"
+        ];
+      };
+    }
+    // pkgs.lib.optionalAttrs (packages ? rocm) {
+      rocm-torch-runtime-deps = mkTorchRuntimeDeps {
+        backend = "rocm";
+        removedRequirements = [ "triton-rocm" ];
+      };
+    }
+    // pkgs.lib.optionalAttrs (packages ? xpu) {
+      # The XPU wheel keeps its Intel requirements; dontCheckRuntimeDeps waves
+      # them through because the pip names do not match the Nix providers.
+      xpu-torch-runtime-deps = mkTorchRuntimeDeps {
+        backend = "xpu";
+        removedRequirements = [ ];
+      };
+    };
+  # Wheel packages only. The torch checks stay out of this aggregate so a
+  # single CI job never has to realize three multi-gigabyte GPU closures.
   runtimeDepsPackages = {
     facexlib = pythonPackages.facexlib;
     gradio-client = vendoredPackages.gradioClient;
     gradio = vendoredPackages.gradio;
     manager = vendoredPackages.comfyuiManager;
     mss = mssRuntimeDeps;
-  }
-  // pkgs.lib.optionalAttrs (cudaTorchRuntimeDeps != null) {
-    cuda-torch = cudaTorchRuntimeDeps;
   };
   runtimeDepsChecks = pkgs.lib.mapAttrs' (
     name: package: pkgs.lib.nameValuePair "${name}-runtime-deps" package
@@ -228,6 +270,7 @@ in
   );
 }
 // runtimeDepsChecks
+// torchRuntimeDepsChecks
 // pkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)) {
   comfy-extras-imports =
     pkgs.runCommand "comfy-extras-imports"

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -300,6 +300,14 @@ lib.optionalAttrs useCuda {
     };
     dontBuild = true;
     dontConfigure = true;
+    # The 2.5.1 wheel pins sympy==1.13.1, which nixpkgs no longer ships. The
+    # combination has always been what this flake builds and runs, so relax the
+    # bound rather than pin sympy back. Drop this when the wheel is bumped.
+    pythonRelaxDeps = [ "sympy" ];
+    # pythonRelaxDeps normally runs in postBuild, which this prebuilt wheel
+    # skips via dontBuild. Remove this phase override when nixpkgs rewrites
+    # wheel metadata before its runtime dependency check.
+    preInstallPhases = [ "pythonRelaxDepsHook" ];
     propagatedBuildInputs = with final; [
       filelock
       typing-extensions
@@ -307,6 +315,7 @@ lib.optionalAttrs useCuda {
       networkx
       jinja2
       fsspec
+      setuptools
     ];
     pythonImportsCheck = [ "torch" ];
     doCheck = false;
@@ -391,6 +400,11 @@ lib.optionalAttrs useCuda {
     ];
     buildInputs = wheelBuildInputs ++ rocmLibs;
 
+    # The ROCm wheel names triton-rocm, which is provided by the bundled ROCm
+    # runtime rather than a PyPI package. The runtime dependency hook cannot
+    # recognize that provider, so validate the rewritten installed metadata in
+    # the rocm-torch-runtime-deps check instead.
+    dontCheckRuntimeDeps = true;
     # These are provided by nixpkgs rocmPackages, not PyPI packages
     postInstall = ''
       for metadata in "$out/${final.python.sitePackages}"/torch-*.dist-info/METADATA; do
@@ -407,6 +421,7 @@ lib.optionalAttrs useCuda {
       networkx
       jinja2
       fsspec
+      setuptools
     ];
     # Don't check for ROCm at import time (requires GPU)
     pythonImportsCheck = [ ];
@@ -675,6 +690,7 @@ lib.optionalAttrs useCuda {
           networkx
           jinja2
           fsspec
+          setuptools
         ])
         ++ [ tritonXpu ];
       propagatedNativeBuildInputs = [ intelOneapiRuntime ];


### PR DESCRIPTION
## Summary

Follow-up to #88. That PR fixed the CUDA backend and added a hook-enabled CI job, but the torch check it added does not test the package it names, and three of the four torch backends still carry the same metadata defects it fixed for CUDA.

- point the torch runtime-dependency check at the backend-specific interpreter instead of the unoverridden nixpkgs package set
- extend that check to ROCm and Intel XPU, and assert the built torch carries the expected local version tag
- declare `setuptools` for the ROCm, XPU, and macOS torch wheels
- guard the ROCm wheel's stripped `triton-rocm` requirement with `dontCheckRuntimeDeps`
- relax the macOS wheel's `sympy==1.13.1` pin, which nixpkgs can no longer satisfy
- split the CI job into a matrix so no single runner realizes three GPU torch closures

## The check tested the wrong package

`nix/checks.nix` reached the CUDA interpreter through `packages.cuda.pythonRuntime.pkgs`. On a `python.withPackages` environment, `.pkgs` is the **unoverridden** `python312Packages`, not the set built from `nix/python-overrides.nix`:

```console
$ nix eval --impure --json --expr '
    let f = builtins.getFlake "git+file://$PWD";
        pr = f.packages.x86_64-linux.cuda.pythonRuntime;
    in { envPkgsTorch = pr.pkgs.torch.name; hasFacexlib = pr.pkgs ? facexlib; }'
{"envPkgsTorch":"python3.12-torch-2.9.1","hasFacexlib":false}
```

`2.9.1` is nixpkgs' stock CPU torch; `nix/versions.nix` pins the cu130 wheel at `2.10.0`. `facexlib` is missing because it only exists in the overridden set. So the check built stock torch, found no `nvidia-*` requirements (stock torch has none), and passed vacuously — the CUDA metadata rewrite in #88 was never exercised.

Routing through `mkPython` resolves the wheel:

```console
$ nix eval ... '(mk "cuda").pkgs.torch.name'   → "python3.12-torch-2.10.0"
```

`flake.nix` now passes `pythonFor = mkPython pkgs` (a function) rather than a single fixed package set, and `nix/checks.nix` derives `pythonPackages = (pythonFor "none").pkgs` from it. Each torch check additionally asserts the local version tag (`+cu` / `+rocm` / `+xpu`), so a regression back to the stock CPU torch fails loudly instead of passing quietly.

## The other three backends have the same defects

Metadata read directly from each pinned wheel (HTTP range requests against the `.dist-info/METADATA` member, no full download):

| backend | torch | `setuptools` requirement | non-PyPI requirement | previously guarded |
|---|---|---|---|---|
| CUDA | `2.10.0+cu130` | declared — fixed in #88 | `cuda-bindings`, `nvidia-*`, `triton` | yes, #88 |
| ROCm | `2.10.0+rocm7.1` | declared — **was missing** | `triton-rocm==3.6.0` | **no** |
| XPU | `2.10.0+xpu` | declared — **was missing** | 20 `intel-*`/`onemkl-*` + `triton-xpu` | yes, pre-existing |
| macOS arm64 | `2.5.1` | declared — **was missing** | — | n/a |

`setuptools; python_version >= "3.12"` is a real requirement on all four wheels, so declaring it is a correctness fix independent of the hook.

ROCm additionally strips `Requires-Dist: triton-rocm` in `postInstall`, but the runtime-dependency hook runs in `preInstallPhases` — before that rewrite. Without `dontCheckRuntimeDeps` the ROCm build fails on the hook-enabled nixpkgs exactly as CUDA did in #81. The stripping `sed` itself is correct: the wheel's requirement really is spelled `triton-rocm`, not `pytorch-triton-rocm`.

macOS is a third failure mode. The pinned 2.5.1 wheel requires `sympy==1.13.1`, and nixpkgs ships `1.14.0` on both the current pin and the CI-pinned revision. That combination is what this flake already builds and runs, so the bound is relaxed rather than sympy pinned back. `dontBuild = true` means the relax hook needs the same `preInstallPhases` override #88 introduced for facexlib.

macOS remains outside CI coverage — the runtime-deps job is `x86_64-linux` only.

## CI shape

The aggregate `python-runtime-deps` link farm now holds only the light wheel packages. The three torch checks are separate check attributes, and the workflow job became a matrix over all four. Bundling them would have asked one `ubuntu-latest` runner to realize the CUDA, ROCm, and XPU torch closures in a single job.

`fail-fast: false` so one backend's failure still reports the others.

## Verification

```console
$ nix build .#checks.x86_64-linux.cuda-torch-runtime-deps \
            .#checks.x86_64-linux.rocm-torch-runtime-deps \
            .#checks.x86_64-linux.xpu-torch-runtime-deps \
            .#checks.x86_64-linux.nixfmt \
            .#checks.x86_64-linux.shellcheck \
            --no-link --print-build-logs
```

## Not addressed

The `mss` `doCheck = false` override added in #88 looks unnecessary. Stock `python312Packages.mss` builds with its tests enabled on the exact revision `nix/versions.nix` pins for the CI job:

```console
$ nix build --no-link github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0#python312Packages.mss
/nix/store/3gf0lpmf67wlg0kcpylpf30f2md1yfr1-python3.12-mss-10.1.0
```

Left in place pending the failure log that motivated it. Raised separately rather than reverted here.
